### PR TITLE
Fix/phpunit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,15 @@
 /config/config.ini
 /public/styles/palette.css
 
-# third party libraries... we manage these with yarn
+# third party libraries... we manage these with yarn/composer
+.composer.lock
 /public/vendor/
+/public/js/.bin/
+/public/js/file-saver/
+/public/js/hellojs/
+/public/js/moostaka/
+/public/js/mustache/
+/public/js/.yarn-integrity
 
 # third party libraries used only for testing... we manage these with composer
 /vendor/
@@ -14,9 +21,5 @@
 # ignore log files
 /logs/
 
-/public/js/.bin/
-/public/js/file-saver/
-/public/js/hellojs/
-/public/js/moostaka/
-/public/js/mustache/
-/public/js/.yarn-integrity
+# test results
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In some shell commands you may need to provide values left up to you. These valu
 This project is licensed under the Apache 2.0 License - see the LICENSE file for details
 
 ## Supported Server Environments
-Makerportal requires PHP version 5.4+ and is known to work with:
+Makerportal requires PHP version 7.4+ and is known to work with:
 
  - Apache 2.4 + mod_php
  - Nginx 1.12 + PHP-FPM
@@ -34,6 +34,13 @@ Occasionally, it may be necessary to provide a helper function for PHP. We suppo
 - validate_email - Provides for custom validation of email addresses. It take one string parameter, the email address to validate and returns the boolean constant FALSE if the email address could not be mapped to a valid email address otherwise it returns a string representing the email address to store in the database which may not be the same as the input email address.
 
 ## Installation
+
+If you have not already setup the database shared by the components of the portalbox ecosystem already start with that first.
+
+[Portalbox Database](https://github.com/Bucknell-ECE/PortalBox-database)
+
+Assuming you have setup the database shared by the PortalBox Ecosystem already:
+
 1) Clone this repository somewhere convenient. This will henceforth be referred to as ${PROJECT_DIRECTORY}.
 2) Install the dependencies
 	Using yarn (https://yarnpkg.com):
@@ -54,8 +61,16 @@ A unit test suite is included for testing PHP code. To use it you will need `php
 ```sh
 cd ${PROJECT_DIRECTORY}
 composer install
-vendor/bin/phpunit test
+vendor/bin/phpunit
 ```
+
+Note by default phpunit will attempt to use the database configured in `config/config.ini` to test database related modules. You can exclude the database tests by running
+
+```sh
+vendor/bin/phpunit --testsuite ci
+```
+
+instead.
 
 ### Integration Testing
 The REST API exposed by this project project can be tested on your development machine using the webserver built in to the PHP CLI. Assuming you have followed steps 1 through 4 under Installation, you can in theory open a command shell and issue:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Occasionally, it may be necessary to provide a helper function for PHP. We suppo
 
 ## Installation
 1) Clone this repository somewhere convenient. This will henceforth be referred to as ${PROJECT_DIRECTORY}.
-2) Install the dependancies
+2) Install the dependencies
 	Using yarn (https://yarnpkg.com):
 
 	```sh
@@ -68,7 +68,7 @@ php -S localhost:8000
 You should then be able to use the requests available in the included [Postman](https://www.postman.com/) collection, see `documentation/api.postman_collection.json`, after setting reasonable collection variable values to test the API.
 
 ### Live Testing
-Various OAuth2 providers restrict the "redirect" URL to be a public URL. With these OAuth2 providers you may be able to test locally by adding an alias for your local machine to a nonexistant domain or subdomain of your domain in your `/etc/hosts` file and enter that same nonexistant domain/subdomain as an authorized redirect URI for your OAuth Client ID credential. E.g.
+Various OAuth2 providers restrict the "redirect" URL to be a public URL. With these OAuth2 providers you may be able to test locally by adding an alias for your local machine to a nonexistent domain or subdomain of your domain in your `/etc/hosts` file and enter that same nonexistent domain/subdomain as an authorized redirect URI for your OAuth Client ID credential. E.g.
 
 ```
 sudo echo "127.0.0.1	dev.bucknell.edu" >> /ect/hosts
@@ -79,7 +79,7 @@ php -S localhost:8000
 provided your API token has a redirect URL of: dev.bucknell.edu:8000
 
 ## Security
-You should take care to prevent the contents of the `config` directory from being publically accessible. Should you discover a security issue please send us an email: mlampart at bucknell dot edu and tom at tomegan dot tech. We will do our best to work with you to resolve the issue and credit you *or* create a pull request with a solution. Be aware we are volunteers and may not be able to respond immediately.
+You should take care to prevent the contents of the `config` directory from being publicly accessible. Should you discover a security issue please send us an email: mlampart at bucknell dot edu and tom at tomegan dot tech. We will do our best to work with you to resolve the issue and credit you *or* create a pull request with a solution. Be aware we are volunteers and may not be able to respond immediately.
 
 ## Author
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.1/phpunit.xsd"
+    defaultTestSuite="all"
+>
+    <testsuites>
+        <testsuite name="all">
+            <directory>test</directory>
+        </testsuite>
+        <testsuite name="ci">
+            <directory>test</directory>
+            <exclude>test/Model</exclude>
+            <exclude>test/Transform</exclude>
+        </testsuite>
+    </testsuites>
+    <logging/>
+</phpunit>

--- a/src/Config.php
+++ b/src/Config.php
@@ -11,7 +11,7 @@ use Portalbox\Exception\InvalidConfigurationException;
  * configuration so we make the configuration a singleton
  */
 class Config {
-	/** The singelton instance */
+	/** The singleton instance */
 	private static $instance;
 
 	/** Cached configuration data */
@@ -19,15 +19,15 @@ class Config {
 
 	/** Cached DB connection */
 	private $connection;
-	
+
 	/**
 	 * __construct - reads the specified config file or if one is not specified
 	 *     looks for a file named 'config.ini' in the include path. Using the
 	 *     settings in the config file it then creates a PDO database instance
 	 *
 	 * @param file - the name of the config file to read. Defaults to
-	 *     '../config/config.ini' ie a fle named 'config.ini' in a directory
-	 *     named 'config' in thesame directory as src.
+	 *     '../config/config.ini' ie a file named 'config.ini' in a directory
+	 *     named 'config' in the same directory as src.
 	 *
 	 * @sideeffect - if the config file can not be found and read, script
 	 *     execution will end abnormally
@@ -36,12 +36,9 @@ class Config {
 		$path = realpath(__DIR__ . DIRECTORY_SEPARATOR . $file);
 		$this->settings = parse_ini_file($path, TRUE);
 	}
-	
+
 	/**
 	 * config - accessor to the configuration singleton
-	 *
-	 * @param file - the name of the config file to read. Defaults to
-	 *     '../config/config.ini'
 	 *
 	 * @return Config - the singleton configuration
 	 */
@@ -76,7 +73,7 @@ class Config {
 	/**
 	 * Get a database connection using the configured connection params
 	 * that can write (INSERT, UPDATE, DELETE) to the db
-	 * 
+	 *
 	 * In a scaled out deployment it may be necessary to have replication
 	 * slaves take some of the load. They can easily take read load without
 	 * a complicated replication setup. By using this method to get a writable
@@ -94,7 +91,7 @@ class Config {
 	/**
 	 * Get a database connection using the configured connection params
 	 * that can only read from the db
-	 * 
+	 *
 	 * In a scaled out deployment it may be necessary to have replication
 	 * slaves take some of the load. They can easily take read load without
 	 * a complicated replication setup. By using this method to get a read only

--- a/src/Entity/ChargePolicy.php
+++ b/src/Entity/ChargePolicy.php
@@ -7,9 +7,9 @@ use ReflectionClass;
 /**
  * ChargePolicy represents how the equipment type charge rate in turned into a
  * charge when an activation session ends... as a stored procedure in the
- * database does the calculation, ChargePolicies occupy a privleged role
+ * database does the calculation, ChargePolicies occupy a privileged role
  * and are difficult to change so they are predefined
- * 
+ *
  * @package Portalbox\Entity
  */
 class ChargePolicy {
@@ -52,7 +52,7 @@ class ChargePolicy {
 
 	/**
 	 * Get the name for the charge policy
-	 * 
+	 *
 	 * @param int policy_id - the policy id to check
 	 * @return string - name for the charge policy
 	 */

--- a/src/Entity/ChargePolicy.php
+++ b/src/Entity/ChargePolicy.php
@@ -2,8 +2,6 @@
 
 namespace Portalbox\Entity;
 
-use ReflectionClass;
-
 /**
  * ChargePolicy represents how the equipment type charge rate in turned into a
  * charge when an activation session ends... as a stored procedure in the
@@ -41,8 +39,13 @@ class ChargePolicy {
 	 * @param int policy_id - the policy id to check
 	 * @return bool - true iff the policy id is valid
 	 */
-	public static function is_valid(int $policy_id) {
-		$valid_values = array_values((new ReflectionClass(get_class()))->getConstants());
+	public static function is_valid(int $policy_id): bool {
+		$valid_values = [
+			self::MANUALLY_ADJUSTED,
+			self::NO_CHARGE,
+			self::PER_USE,
+			self::PER_MINUTE
+		];
 		if(in_array($policy_id, $valid_values)) {
 			return true;
 		}

--- a/src/Entity/Equipment.php
+++ b/src/Entity/Equipment.php
@@ -6,7 +6,7 @@ use InvalidArgumentException;
 
 /**
  * Equipment represents a machine connected to a Portalbox.
- * 
+ *
  * @package Portalbox\Entity
  */
 class Equipment extends AbstractEntity {
@@ -56,7 +56,7 @@ class Equipment extends AbstractEntity {
 	/**
 	 * The default maximum duration of an activation session for this
 	 * equipment in seconds
-	 * 
+	 *
 	 * @var int
 	 */
 	protected $timeout;
@@ -83,9 +83,9 @@ class Equipment extends AbstractEntity {
 	protected $service_minutes;
 
 	/**
-	 * The ip Address of the box 
+	 * The ip Address of the box
 	 *
-	 * @var string
+	 * @var ?string
 	 */
 	protected $ip_address;
 
@@ -94,6 +94,7 @@ class Equipment extends AbstractEntity {
 	 */
 	public function __construct() {
 		$this->set_service_minutes(0);
+		$this->set_ip_address(null);
 	}
 
 	/**

--- a/src/Entity/EquipmentType.php
+++ b/src/Entity/EquipmentType.php
@@ -3,11 +3,10 @@
 namespace Portalbox\Entity;
 
 use InvalidArgumentException;
-use ReflectionClass;
 
 /**
  * Equipment Type binds policy to equipment of the same type
- * 
+ *
  * @package Portalbox\Entity
  */
 class EquipmentType extends AbstractEntity {
@@ -36,7 +35,7 @@ class EquipmentType extends AbstractEntity {
 	/**
 	 * The id of the Charge policy for this equipment type
 	 *
-	 * @var 
+	 * @var
 	 */
 	protected $charge_policy_id;
 
@@ -148,7 +147,7 @@ class EquipmentType extends AbstractEntity {
 			$this->charge_policy_id = $charge_policy_id;
 			return $this;
 		}
-		
+
 		throw new InvalidArgumentException("charge_policy_id must be one of the public constants from ChargePolicy");
 	}
 

--- a/src/Entity/LoggedEventType.php
+++ b/src/Entity/LoggedEventType.php
@@ -2,8 +2,6 @@
 
 namespace Portalbox\Entity;
 
-use ReflectionClass;
-
 /**
  * LoggedEventType represents the type of a log event.
  *
@@ -45,8 +43,14 @@ class LoggedEventType {
 	 * @param int type - the type to check
 	 * @return bool - true iff the type is valid
 	 */
-	public static function is_valid(int $type) {
-		$valid_values = array_values((new ReflectionClass(get_class()))->getConstants());
+	public static function is_valid(int $type): bool {
+		$valid_values = [
+			self::UNSUCCESSFUL_AUTHENTICATION,
+			self::SUCCESSFUL_AUTHENTICATION,
+			self::DEAUTHENTICATION,
+			self::STARTUP_COMPLETE,
+			self::PLANNED_SHUTDOWN
+		];
 		if(in_array($type, $valid_values)) {
 			return true;
 		}

--- a/src/Entity/LoggedEventType.php
+++ b/src/Entity/LoggedEventType.php
@@ -6,7 +6,7 @@ use ReflectionClass;
 
 /**
  * LoggedEventType represents the type of a log event.
- * 
+ *
  * @package Portalbox\Entity
  */
 class LoggedEventType {
@@ -14,14 +14,14 @@ class LoggedEventType {
 	 * A card was presented but misread, not in the system, or was assigned to
 	 * a user who did not have permission to use the equipment
 	 */
-	const UNSUCESSFUL_AUTHENTICATION = 1;
+	const UNSUCCESSFUL_AUTHENTICATION = 1;
 
 	/**
 	 * A user or training card activated the equipment
 	 */
-	const SUCESSFUL_AUTHENTICATION = 2;
+	const SUCCESSFUL_AUTHENTICATION = 2;
 
-	/** 
+	/**
 	 * The card keeping a portalbox activated was removed, not returned or
 	 * replaced with a proxy card thus the portalbox service ended the
 	 * equipment activation
@@ -56,14 +56,14 @@ class LoggedEventType {
 
 	/**
 	 * Get the name for the event type
-	 * 
+	 *
 	 * @param int type_id - the policy id to check
 	 * @return string - name for the event type
 	 */
 	public static function name_for_type(int $type_id) : string {
 		switch($type_id) {
-			case self::UNSUCESSFUL_AUTHENTICATION: return 'Failed Authentication';
-			case self::SUCESSFUL_AUTHENTICATION: return 'Activation Session Begun';
+			case self::UNSUCCESSFUL_AUTHENTICATION: return 'Failed Authentication';
+			case self::SUCCESSFUL_AUTHENTICATION: return 'Activation Session Begun';
 			case self::DEAUTHENTICATION: return 'Activation Session Ended';
 			case self::STARTUP_COMPLETE: return 'Startup Complete';
 			case self::PLANNED_SHUTDOWN: return 'Planned Shutdown';

--- a/src/Entity/Payment.php
+++ b/src/Entity/Payment.php
@@ -5,7 +5,7 @@ namespace Portalbox\Entity;
 /**
  * Payment represents a payment made by the user to the operator of the
  * portalbox network
- * 
+ *
  * @package Portalbox\Entity
  */
 class Payment extends AbstractEntity {
@@ -30,6 +30,13 @@ class Payment extends AbstractEntity {
 	 * @var string
 	 */
 	protected $time;
+
+	/**
+	 * The user who made this payment
+	 *
+	 * @var User|null
+	 */
+	private $user = null;
 
 	/**
 	 * Get the id of the user who paid

--- a/src/Entity/Permission.php
+++ b/src/Entity/Permission.php
@@ -2,11 +2,9 @@
 
 namespace Portalbox\Entity;
 
-use ReflectionClass;
-
 /**
  * Permission represents a permission which a particular role may have
- * 
+ *
  * @package Portalbox\Entity
  */
 class Permission {
@@ -30,14 +28,14 @@ class Permission {
 
 	/**
 	 * Users with this permission can read equipment authorizations
-	 * 
+	 *
 	 * Currently unused; Listing is sufficient in the current design
 	 */
 	//const READ_EQUIPMENT_AUTHORIZATION = 102;
 
 	/**
 	 * Users with this permission can modify authorizations
-	 * 
+	 *
 	 * Currently unused; users have a list of authorizations... either they
 	 * have authorization or they don't. So creating and deleting a user's
 	 * authorizations are sufficient in the current model
@@ -103,7 +101,7 @@ class Permission {
 	/** Users with this permission can modify equipment access cards */
 	const MODIFY_CARD = 303;
 
-	/** 
+	/**
 	 * Users with this permission can delete equipment access cards
 	 *
 	 * Currently usused and probably never will be used as our logs have a
@@ -118,7 +116,7 @@ class Permission {
 	const LIST_OWN_CARDS = 306;
 
 	/** Users with this permission can create charge policies
-	 * 
+	 *
 	 * Charge policies play a special role in the system as designed. Stored
 	 * Procedures in the database make decisions based on charge policy thus
 	 * policies are implemented as constants in code.
@@ -126,7 +124,7 @@ class Permission {
 	const CREATE_CHARGE_POLICY = 401;
 
 	/** Users with this permission can read charge policies
-	 * 
+	 *
 	 * Charge policies play a special role in the system as designed. Stored
 	 * Procedures in the database make decisions based on charge policy thus
 	 * policies are implemented as constants in code.
@@ -134,7 +132,7 @@ class Permission {
 	const READ_CHARGE_POLICY = 402;
 
 	/** Users with this permission can modify charge policies
-	 * 
+	 *
 	 * Charge policies play a special role in the system as designed. Stored
 	 * Procedures in the database make decisions based on charge policy thus
 	 * policies are implemented as constants in code.
@@ -142,7 +140,7 @@ class Permission {
 	const MODIFY_CHARGE_POLICY = 403;
 
 	/** Users with this permission can delete charge policies
-	 * 
+	 *
 	 * Charge policies play a special role in the system as designed. Stored
 	 * Procedures in the database make decisions based on charge policy thus
 	 * policies are implemented as constants in code.
@@ -281,7 +279,7 @@ class Permission {
 
 	/** Users with this permission can view the roles page */
 	const VIEW_ROLES = 1107;
-	
+
 	/** Users with this permission can create users */
 	const CREATE_USER = 1201;
 
@@ -306,8 +304,70 @@ class Permission {
 	 * @param int permission - the permission to check
 	 * @return bool - true iff the permission is valid
 	 */
-	public static function is_valid(int $permission) {
-		$valid_values = array_values((new ReflectionClass(get_class()))->getConstants());
+	public static function is_valid(int $permission): bool {
+		$valid_values = [
+			self::CREATE_API_KEY,
+			self::READ_API_KEY,
+			self::MODIFY_API_KEY,
+			self::DELETE_API_KEY,
+			self::LIST_API_KEYS,
+			self::CREATE_EQUIPMENT_AUTHORIZATION,
+			self::DELETE_EQUIPMENT_AUTHORIZATION,
+			self::LIST_EQUIPMENT_AUTHORIZATIONS,
+			self::LIST_OWN_EQUIPMENT_AUTHORIZATIONS,
+			self::LIST_CARD_TYPES,
+			self::CREATE_CARD,
+			self::READ_CARD,
+			self::MODIFY_CARD,
+			self::LIST_CARDS,
+			self::LIST_OWN_CARDS,
+			self::CREATE_CHARGE_POLICY,
+			self::READ_CHARGE_POLICY,
+			self::MODIFY_CHARGE_POLICY,
+			self::DELETE_CHARGE_POLICY,
+			self::LIST_CHARGE_POLICIES,
+			self::CREATE_CHARGE,
+			self::READ_CHARGE,
+			self::MODIFY_CHARGE,
+			self::DELETE_CHARGE,
+			self::LIST_CHARGES,
+			self::LIST_OWN_CHARGES,
+			self::CREATE_EQUIPMENT_TYPE,
+			self::READ_EQUIPMENT_TYPE,
+			self::MODIFY_EQUIPMENT_TYPE,
+			self::DELETE_EQUIPMENT_TYPE,
+			self::LIST_EQUIPMENT_TYPES,
+			self::CREATE_EQUIPMENT,
+			self::READ_EQUIPMENT,
+			self::MODIFY_EQUIPMENT,
+			self::DELETE_EQUIPMENT,
+			self::LIST_EQUIPMENT,
+			self::CREATE_LOCATION,
+			self::READ_LOCATION,
+			self::MODIFY_LOCATION,
+			self::DELETE_LOCATION,
+			self::LIST_LOCATIONS,
+			self::READ_LOG,
+			self::LIST_LOGS,
+			self::CREATE_PAYMENT,
+			self::READ_PAYMENT,
+			self::MODIFY_PAYMENT,
+			self::DELETE_PAYMENT,
+			self::LIST_PAYMENTS,
+			self::LIST_OWN_PAYMENTS,
+			self::CREATE_ROLE,
+			self::READ_ROLE,
+			self::MODIFY_ROLE,
+			self::DELETE_ROLE,
+			self::LIST_ROLES,
+			self::VIEW_ROLES,
+			self::CREATE_USER,
+			self::READ_USER,
+			self::MODIFY_USER,
+			self::DELETE_USER,
+			self::LIST_USERS,
+			self::READ_OWN_USER,
+		];
 		if(in_array($permission, $valid_values)) {
 			return true;
 		}

--- a/src/Entity/Role.php
+++ b/src/Entity/Role.php
@@ -6,10 +6,10 @@ use InvalidArgumentException;
 
 /**
  * Role represents an assignable group of permissions.
- * 
+ *
  * Every user is assigned a role and thus has a set of permissions restricting
  * what they can do in the web portal.
- * 
+ *
  * @package Portalbox\Entity
  */
 class Role extends AbstractEntity {
@@ -146,5 +146,5 @@ class Role extends AbstractEntity {
 			return FALSE;
 		}
 	}
-	
+
 }

--- a/src/Entity/TrainingCard.php
+++ b/src/Entity/TrainingCard.php
@@ -4,16 +4,25 @@ namespace Portalbox\Entity;
 
 /**
  * Cards come in a number of types and when presented to a portalbox, the
- * portalbox shutsdown when presented with cards of this type.
- * 
+ * portalbox shuts down when presented with cards of this type.
+ *
  * @package Portalbox\Entity
  */
 class TrainingCard extends AbstractEntity implements Card {
 
 	/**
 	 * The id of the type of equipment this card can activate for training
+	 *
+	 * @var int
 	 */
 	private $equipment_type_id;
+
+	/**
+	 * The type of equipment this card can activate for training
+	 *
+	 * @var EquipmentType|null
+	 */
+	private $equipment_type = null;
 
 	/**
 	 * Get the type of the card

--- a/src/Entity/UserCard.php
+++ b/src/Entity/UserCard.php
@@ -5,15 +5,24 @@ namespace Portalbox\Entity;
 /**
  * Cards come in a number of types and when presented to a portalbox, the
  * portalbox shutsdown when presented with cards of this type.
- * 
+ *
  * @package Portalbox\Entity
  */
 class UserCard extends AbstractEntity implements Card {
 
 	/**
 	 * The id of the user this card was issued to
+	 *
+	 * @var int
 	 */
 	private $user_id;
+
+	/**
+	 * The user this card was issued to
+	 *
+	 * @var User|null
+	 */
+	private $user = null;
 
 	/**
 	 * Get the type of the card

--- a/src/Query/ChargeQuery.php
+++ b/src/Query/ChargeQuery.php
@@ -4,37 +4,37 @@ namespace Portalbox\Query;
 
 /**
  * ChargeQuery presents a standard interface for Charge search queries
- * 
+ *
  * @package Portalbox\Query
  */
 class ChargeQuery {
 	/**
 	 * Find charges on or before this date
 	 *
-	 * @var string
+	 * @var ?string
 	 */
-	protected $on_or_before;
+	protected $on_or_before = null;
 
 	/**
 	 * Find charges on or before this date
 	 *
-	 * @var string
+	 * @var ?string
 	 */
-	protected $on_or_after;
+	protected $on_or_after = null;
 
 	/**
 	 * Find charges for this equipment
 	 *
-	 * @var int
+	 * @var ?int
 	 */
-	protected $equipment_id;
+	protected $equipment_id = null;
 
 	/**
 	 * Find charges for this user
 	 *
-	 * @var int
+	 * @var ?int
 	 */
-	protected $user_id;
+	protected $user_id = null;
 
 
 	/**

--- a/src/Transform/EquipmentTransformer.php
+++ b/src/Transform/EquipmentTransformer.php
@@ -15,13 +15,13 @@ use Portalbox\Model\LocationModel;
 /**
  * EquipmentTransformer is our bridge between dictionary representations and
  * Equipment entity instances.
- * 
+ *
  * @package Portalbox\Transform
  */
 class EquipmentTransformer implements InputTransformer, OutputTransformer {
 	/**
 	 * Deserialize a Equipment entity object from a dictionary
-	 * 
+	 *
 	 * @param array data - a dictionary representing a Equipment
 	 * @return Equipment - a valid entity object based on the data specified
 	 * @throws InvalidArgumentException if a require field is not specified
@@ -46,6 +46,12 @@ class EquipmentTransformer implements InputTransformer, OutputTransformer {
 			throw new InvalidArgumentException('\'in_service\' is a required field');
 		}
 
+		// service minutes is optional and should default to 0
+		$service_minutes = 0;
+		if(array_key_exists('service_minutes', $data)) {
+			$service_minutes = intval($data["service_minutes"]);
+		}
+
 		$type = (new EquipmentTypeModel(Config::config()))->read($data['type_id']);
 		if(NULL === $type) {
 			throw new InvalidArgumentException('\'type_id\' must correspond to a valid equiment type');
@@ -62,13 +68,13 @@ class EquipmentTransformer implements InputTransformer, OutputTransformer {
 			->set_mac_address($data['mac_address'])
 			->set_timeout($data['timeout'])
 			->set_is_in_service($data['in_service'])
-			->set_service_minutes($data["service_minutes"]);
+			->set_service_minutes($service_minutes);
 	}
 
 	/**
 	 * Called to serialize Equipment entity instance to a dictionary
 	 *
-	 * @param bool $traverse - traverse the object graph if true, otherwise 
+	 * @param bool $traverse - traverse the object graph if true, otherwise
 	 *      may substitute flattened representations where appropriate.
 	 * @return array -  a dictionary whose values are null, string, int, float
 	 *      dictionaries, or arrays with the compound types having the same
@@ -111,7 +117,7 @@ class EquipmentTransformer implements InputTransformer, OutputTransformer {
 	 * Called to get the column headers for a tabular output format eg csv.
 	 * The column count should match the number of fields in an array returned
 	 * by serialize() when $traverse is false
-	 * 
+	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
 	public function get_column_headers() : array {

--- a/test/Entity/EquipmentTest.php
+++ b/test/Entity/EquipmentTest.php
@@ -38,6 +38,9 @@ final class EquipmentTest extends TestCase {
 		$is_in_use = false;
 		$service_minutes = 500;
 
+		// nullables
+		$ip_address = '172.0.0.1';
+
 		$equipment = (new Equipment())
 			->set_id($id)
 			->set_name($name)
@@ -60,5 +63,9 @@ final class EquipmentTest extends TestCase {
 		self::assertEquals($is_in_service, $equipment->is_in_service());
 		self::assertEquals($is_in_use, $equipment->is_in_use());
 		self::assertEquals($service_minutes, $equipment->service_minutes());
+		self::assertNull($equipment->ip_address());
+
+		$equipment->set_ip_address($ip_address);
+		self::assertEquals($ip_address, $equipment->ip_address());
 	}
 }

--- a/test/Entity/EquipmentTypeTest.php
+++ b/test/Entity/EquipmentTypeTest.php
@@ -14,19 +14,22 @@ final class EquipmentTypeTest extends TestCase {
 		$requires_training = TRUE;
 		$charge_rate = "2.50";
 		$charge_policy_id = ChargePolicy::PER_USE;
+		$allow_proxy = true;
 
 		$type = (new EquipmentType())
 			->set_id($id)
 			->set_name($name)
 			->set_requires_training($requires_training)
 			->set_charge_rate($charge_rate)
-			->set_charge_policy_id($charge_policy_id);
+			->set_charge_policy_id($charge_policy_id)
+			->set_allow_proxy($allow_proxy);
 
 		self::assertEquals($id, $type->id());
 		self::assertEquals($name, $type->name());
 		self::assertEquals($requires_training, $type->requires_training());
 		self::assertEquals($charge_rate, $type->charge_rate());
 		self::assertEquals($charge_policy_id, $type->charge_policy_id());
+		self::assertEquals($allow_proxy, $type->allow_proxy());
 	}
 
 	public function testInvalidChargePolicyTriggersException(): void {

--- a/test/Entity/LoggedEventTest.php
+++ b/test/Entity/LoggedEventTest.php
@@ -11,7 +11,7 @@ final class LoggedEventTest extends TestCase {
 	public function testAgreement(): void {
 		$id = 981726354;
 		$time = '2020-05-10 09:54:12';
-		$type_id = LoggedEventType::SUCESSFUL_AUTHENTICATION;
+		$type_id = LoggedEventType::SUCCESSFUL_AUTHENTICATION;
 		$equipment_id = 42;
 		// $equipment = ???;
 		$card_id = 1234;

--- a/test/Model/CardModelTest.php
+++ b/test/Model/CardModelTest.php
@@ -47,7 +47,7 @@ final class CardModelTest extends TestCase {
 	private static $config;
 
 	public static function setUpBeforeClass(): void {
-		parent::setUp();
+		parent::setUpBeforeClass();
 		self::$config = Config::config();
 
 		// provision a location in the db
@@ -70,7 +70,8 @@ final class CardModelTest extends TestCase {
 		$equipment_type = (new EquipmentType())
 			->set_name($name)
 			->set_requires_training($requires_training)
-			->set_charge_policy_id($charge_policy_id);
+			->set_charge_policy_id($charge_policy_id)
+			->set_allow_proxy(false);
 
 		self::$equipment_type = $model->create($equipment_type);
 
@@ -109,6 +110,8 @@ final class CardModelTest extends TestCase {
 		// deprovision a user in the db
 		$model = new UserModel(self::$config);
 		$model->delete(self::$user->id());
+
+		parent::tearDownAfterClass();
 	}
 
 	public function testProxyCardModel(): void {

--- a/test/Model/ChargeModelTest.php
+++ b/test/Model/ChargeModelTest.php
@@ -48,7 +48,7 @@ final class ChargeModelTest extends TestCase {
 	private static $config;
 
 	public static function setUpBeforeClass(): void {
-		parent::setUp();
+		parent::setUpBeforeClass();
 		self::$config = Config::config();
 
 		// provision a user in the db
@@ -93,7 +93,8 @@ final class ChargeModelTest extends TestCase {
 		$type = (new EquipmentType())
 			->set_name($name)
 			->set_requires_training($requires_training)
-			->set_charge_policy_id($charge_policy_id);
+			->set_charge_policy_id($charge_policy_id)
+			->set_allow_proxy(false);
 
 		self::$type = $model->create($type);
 
@@ -134,6 +135,8 @@ final class ChargeModelTest extends TestCase {
 		// deprovision an equipment type in the db
 		$model = new EquipmentTypeModel(self::$config);
 		$model->delete(self::$type->id());
+
+		parent::tearDownAfterClass();
 	}
 
 	public function testModel(): void {

--- a/test/Model/EquipmentModelTest.php
+++ b/test/Model/EquipmentModelTest.php
@@ -32,7 +32,7 @@ final class EquipmentModelTest extends TestCase {
 	private static $config;
 
 	public static function setUpBeforeClass(): void {
-		parent::setUp();
+		parent::setUpBeforeClass();
 		self::$config = Config::config();
 
 		// provision a location in the db
@@ -55,7 +55,8 @@ final class EquipmentModelTest extends TestCase {
 		$type = (new EquipmentType())
 			->set_name($name)
 			->set_requires_training($requires_training)
-			->set_charge_policy_id($charge_policy_id);
+			->set_charge_policy_id($charge_policy_id)
+			->set_allow_proxy(false);
 
 		self::$type = $model->create($type);
 	}
@@ -68,6 +69,8 @@ final class EquipmentModelTest extends TestCase {
 		// deprovision an equipment type in the db
 		$model = new EquipmentTypeModel(self::$config);
 		$model->delete(self::$type->id());
+
+		parent::tearDownAfterClass();
 	}
 
 	public function testCRUD(): void {
@@ -99,6 +102,7 @@ final class EquipmentModelTest extends TestCase {
 		self::assertEquals($timeout, $equipment_as_created->timeout());
 		self::assertEquals($is_in_service, $equipment_as_created->is_in_service());
 		self::assertEquals($service_minutes, $equipment_as_created->service_minutes());
+		self::assertNull($equipment_as_created->ip_address());
 
 		$equipment_as_found = $model->read($equipment_id);
 
@@ -111,6 +115,7 @@ final class EquipmentModelTest extends TestCase {
 		self::assertEquals($timeout, $equipment_as_found->timeout());
 		self::assertEquals($is_in_service, $equipment_as_found->is_in_service());
 		self::assertEquals($service_minutes, $equipment_as_found->service_minutes());
+		self::assertNull($equipment_as_found->ip_address());
 
 		$name = '2000W Floodlight';
 		$mac_address = 'cdef456789ab';
@@ -136,6 +141,7 @@ final class EquipmentModelTest extends TestCase {
 		self::assertEquals($timeout, $equipment_as_modified->timeout());
 		self::assertEquals($is_in_service, $equipment_as_modified->is_in_service());
 		self::assertEquals($service_minutes, $equipment_as_modified->service_minutes());
+		self::assertNull($equipment_as_modified->ip_address());
 
 		$equipment_as_deleted = $model->delete($equipment_id);
 
@@ -148,10 +154,9 @@ final class EquipmentModelTest extends TestCase {
 		self::assertEquals($timeout, $equipment_as_deleted->timeout());
 		self::assertEquals($is_in_service, $equipment_as_deleted->is_in_service());
 		self::assertEquals($service_minutes, $equipment_as_deleted->service_minutes());
+		self::assertNull($equipment_as_deleted->ip_address());
 
-		$equipment_as_not_found = $model->read($equipment_id);
-
-		self::assertNull($equipment_as_not_found);
+		self::assertNull($model->read($equipment_id));
 	}
 
 	public function testSearch(): void {

--- a/test/Model/EquipmentTypeModelTest.php
+++ b/test/Model/EquipmentTypeModelTest.php
@@ -17,12 +17,14 @@ final class EquipmentTypeModelTest extends TestCase {
 		$requires_training = TRUE;
 		$charge_rate = "0.01";
 		$charge_policy_id = ChargePolicy::PER_MINUTE;
+		$allow_proxy = true;
 
 		$type = (new EquipmentType())
 			->set_name($name)
 			->set_requires_training($requires_training)
 			->set_charge_rate($charge_rate)
-			->set_charge_policy_id($charge_policy_id);
+			->set_charge_policy_id($charge_policy_id)
+			->set_allow_proxy($allow_proxy);
 
 		$type_as_created = $model->create($type);
 
@@ -32,6 +34,7 @@ final class EquipmentTypeModelTest extends TestCase {
 		self::assertEquals($requires_training, $type_as_created->requires_training());
 		self::assertEquals($charge_rate, $type_as_created->charge_rate());
 		self::assertEquals($charge_policy_id, $type_as_created->charge_policy_id());
+		self::assertEquals($allow_proxy, $type_as_created->allow_proxy());
 
 		$type_as_found = $model->read($type_id);
 
@@ -41,17 +44,20 @@ final class EquipmentTypeModelTest extends TestCase {
 		self::assertEquals($requires_training, $type_as_found->requires_training());
 		self::assertEquals($charge_rate, $type_as_found->charge_rate());
 		self::assertEquals($charge_policy_id, $type_as_found->charge_policy_id());
+		self::assertEquals($allow_proxy, $type_as_found->allow_proxy());
 
 		$name = '3D Clay Printer';
 		$requires_training = FALSE;
 		$charge_rate = '2.50';
 		$charge_policy_id = ChargePolicy::PER_USE;
+		$allow_proxy = false;
 
 		$type_as_found
 			->set_name($name)
 			->set_requires_training($requires_training)
 			->set_charge_rate($charge_rate)
-			->set_charge_policy_id($charge_policy_id);
+			->set_charge_policy_id($charge_policy_id)
+			->set_allow_proxy($allow_proxy);
 
 		$type_as_modified = $model->update($type_as_found);
 
@@ -61,6 +67,7 @@ final class EquipmentTypeModelTest extends TestCase {
 		self::assertEquals($requires_training, $type_as_modified->requires_training());
 		self::assertEquals($charge_rate, $type_as_modified->charge_rate());
 		self::assertEquals($charge_policy_id, $type_as_modified->charge_policy_id());
+		self::assertEquals($allow_proxy, $type_as_modified->allow_proxy());
 
 		$types_as_found = $model->search();
 		self::assertIsArray($types_as_found);
@@ -75,9 +82,8 @@ final class EquipmentTypeModelTest extends TestCase {
 		self::assertEquals($requires_training, $type_as_deleted->requires_training());
 		self::assertEquals($charge_rate, $type_as_deleted->charge_rate());
 		self::assertEquals($charge_policy_id, $type_as_deleted->charge_policy_id());
+		self::assertEquals($allow_proxy, $type_as_deleted->allow_proxy());
 
-		$type_as_not_found = $model->read($type_id);
-
-		self::assertNull($type_as_not_found);
+		self::assertNull($model->read($type_id));
 	}
 }

--- a/test/Model/PaymentModelTest.php
+++ b/test/Model/PaymentModelTest.php
@@ -26,7 +26,7 @@ final class PaymentModelTest extends TestCase {
 	private static $config;
 
 	public static function setUpBeforeClass(): void {
-		parent::setUp();
+		parent::setUpBeforeClass();
 		self::$config = Config::config();
 
 		$model = new UserModel(self::$config);
@@ -54,6 +54,8 @@ final class PaymentModelTest extends TestCase {
 	public static function tearDownAfterClass() : void {
 		$model = new UserModel(self::$config);
 		$model->delete(self::$user->id());
+
+		parent::tearDownAfterClass();
 	}
 
 	public function testModel(): void {

--- a/test/Model/UserModelTest.php
+++ b/test/Model/UserModelTest.php
@@ -29,7 +29,7 @@ final class UserModelTest extends TestCase {
 	private static $config;
 
 	public static function setUpBeforeClass(): void {
-		parent::setUp();
+		parent::setUpBeforeClass();
 		self::$config = Config::config();
 
 		// provision an equipment type in the db
@@ -42,7 +42,8 @@ final class UserModelTest extends TestCase {
 		$type = (new EquipmentType())
 			->set_name($name)
 			->set_requires_training($requires_training)
-			->set_charge_policy_id($charge_policy_id);
+			->set_charge_policy_id($charge_policy_id)
+			->set_allow_proxy(false);
 
 		self::$type = $model->create($type);
 	}
@@ -51,6 +52,8 @@ final class UserModelTest extends TestCase {
 		// deprovision an equipment type in the db
 		$model = new EquipmentTypeModel(self::$config);
 		$model->delete(self::$type->id());
+
+		parent::tearDownAfterClass();
 	}
 
 	public function testModel(): void {
@@ -64,7 +67,7 @@ final class UserModelTest extends TestCase {
 		$name = 'Tom Egan';
 		$email = 'tom@ficticious.tld';
 		$comment = 'Test Monkey';
-		$active = TRUE;
+		$active = FALSE;
 		$authorizations = [self::$type->id()];
 		$num_authorizations = count($authorizations);
 
@@ -105,7 +108,7 @@ final class UserModelTest extends TestCase {
 		$name = 'Matt Lamparter';
 		$email = 'matt@ficticious.tld';
 		$comment = 'Test Hominid';
-		$active = FALSE;
+		$active = TRUE;
 
 		$user_as_found
 			->set_name($name)

--- a/test/Transform/ChargeTransformerTest.php
+++ b/test/Transform/ChargeTransformerTest.php
@@ -93,7 +93,8 @@ final class ChargeTransformerTest extends TestCase {
 			->set_name($name)
 			->set_requires_training($requires_training)
 			->set_charge_policy_id($charge_policy_id)
-			->set_charge_rate('2.00');
+			->set_charge_rate('2.00')
+			->set_allow_proxy(false);
 
 		self::$type = $model->create($type);
 
@@ -136,6 +137,8 @@ final class ChargeTransformerTest extends TestCase {
 		// deprovision an equipment type in the db
 		$model = new EquipmentTypeModel($config);
 		$model->delete(self::$type->id());
+
+		parent::tearDownAfterClass();
 	}
 
 	public function testDeserialize(): void {

--- a/test/Transform/EquipmentTransformerTest.php
+++ b/test/Transform/EquipmentTransformerTest.php
@@ -55,7 +55,8 @@ final class EquipmentTransformerTest extends TestCase {
 			->set_name($name)
 			->set_requires_training($requires_training)
 			->set_charge_rate($charge_rate)
-			->set_charge_policy_id($charge_policy_id);
+			->set_charge_policy_id($charge_policy_id)
+			->set_allow_proxy(false);
 
 		self::$type = $model->create($type);
 	}
@@ -70,6 +71,8 @@ final class EquipmentTransformerTest extends TestCase {
 		// deprovision location from the db
 		$model = new LocationModel($config);
 		$model->delete(self::$location->id());
+
+		parent::tearDownAfterClass();
 	}
 
 	public function testDeserialize(): void {
@@ -83,7 +86,9 @@ final class EquipmentTransformerTest extends TestCase {
 		$timeout = 240;
 		$in_service = true;
 		$in_use = false;
+		$service_minutes = 58;
 
+		// test without optional service_minutes
 		$data = [
 			'id' => $id,
 			'name' => $name,
@@ -104,6 +109,31 @@ final class EquipmentTransformerTest extends TestCase {
 		self::assertEquals($mac_address, $equipment->mac_address());
 		self::assertEquals($timeout, $equipment->timeout());
 		self::assertEquals($in_service, $equipment->is_in_service());
+		self::assertEquals(0, $equipment->service_minutes());
+
+		// test with optional service_minutes
+		$data = [
+			'id' => $id,
+			'name' => $name,
+			'type_id' => $type_id,
+			'location_id' => $location_id,
+			'mac_address' => $mac_address,
+			'timeout' => $timeout,
+			'in_service' => $in_service,
+			'in_use' => $in_use,
+			'service_minutes' => $service_minutes
+		];
+
+		$equipment = $transformer->deserialize($data);
+
+		self::assertNotNull($equipment);
+		self::assertNull($equipment->id());
+		self::assertEquals($type_id, $equipment->type_id());
+		self::assertEquals($location_id, $equipment->location_id());
+		self::assertEquals($mac_address, $equipment->mac_address());
+		self::assertEquals($timeout, $equipment->timeout());
+		self::assertEquals($in_service, $equipment->is_in_service());
+		self::assertEquals($service_minutes, $equipment->service_minutes());
 	}
 
 	public function testDeserializeInvalidDataName(): void {

--- a/test/Transform/EquipmentTypeTransformerTest.php
+++ b/test/Transform/EquipmentTypeTransformerTest.php
@@ -18,13 +18,15 @@ final class EquipmentTypeTransformerTest extends TestCase {
 		$charge_rate = "2.50";
 		$charge_policy_id = ChargePolicy::PER_USE;
 		$charge_policy = ChargePolicy::name_for_policy($charge_policy_id);
+		$allow_proxy = false;
 
 		$data = [
 			'id' => $id,
 			'name' => $name,
 			'requires_training' => $requires_training,
 			'charge_rate' => $charge_rate,
-			'charge_policy_id' => $charge_policy_id
+			'charge_policy_id' => $charge_policy_id,
+			'allow_proxy' => $allow_proxy
 		];
 
 		$type = $transformer->deserialize($data);
@@ -36,6 +38,7 @@ final class EquipmentTypeTransformerTest extends TestCase {
 		self::assertEquals($charge_rate, $type->charge_rate());
 		self::assertEquals($charge_policy_id, $type->charge_policy_id());
 		self::assertEquals($charge_policy, $type->charge_policy());
+		self::assertEquals($allow_proxy, $type->allow_proxy());
 	}
 
 	public function testDeserializeInvalidDataName(): void {
@@ -45,12 +48,14 @@ final class EquipmentTypeTransformerTest extends TestCase {
 		$requires_training = TRUE;
 		$charge_rate = "2.50";
 		$charge_policy_id = ChargePolicy::PER_USE;
+		$allow_proxy = false;
 
 		$data = [
 			'id' => $id,
 			'requires_training' => $requires_training,
 			'charge_rate' => $charge_rate,
-			'charge_policy_id' => $charge_policy_id
+			'charge_policy_id' => $charge_policy_id,
+			'allow_proxy' => $allow_proxy
 		];
 
 		$this->expectException(InvalidArgumentException::class);
@@ -64,12 +69,14 @@ final class EquipmentTypeTransformerTest extends TestCase {
 		$name = 'laser scalpel';
 		$charge_rate = "2.50";
 		$charge_policy_id = ChargePolicy::PER_USE;
+		$allow_proxy = false;
 
 		$data = [
 			'id' => $id,
 			'name' => $name,
 			'charge_rate' => $charge_rate,
-			'charge_policy_id' => $charge_policy_id
+			'charge_policy_id' => $charge_policy_id,
+			'allow_proxy' => $allow_proxy
 		];
 
 		$this->expectException(InvalidArgumentException::class);
@@ -83,12 +90,14 @@ final class EquipmentTypeTransformerTest extends TestCase {
 		$name = 'laser scalpel';
 		$requires_training = TRUE;
 		$charge_policy_id = ChargePolicy::PER_USE;
+		$allow_proxy = false;
 
 		$data = [
 			'id' => $id,
 			'name' => $name,
 			'requires_training' => $requires_training,
-			'charge_policy_id' => $charge_policy_id
+			'charge_policy_id' => $charge_policy_id,
+			'allow_proxy' => $allow_proxy
 		];
 
 		$this->expectException(InvalidArgumentException::class);
@@ -102,12 +111,35 @@ final class EquipmentTypeTransformerTest extends TestCase {
 		$name = 'laser scalpel';
 		$requires_training = TRUE;
 		$charge_rate = "2.50";
+		$allow_proxy = false;
 
 		$data = [
 			'id' => $id,
 			'name' => $name,
 			'requires_training' => $requires_training,
-			'charge_rate' => $charge_rate
+			'charge_rate' => $charge_rate,
+			'allow_proxy' => $allow_proxy
+		];
+
+		$this->expectException(InvalidArgumentException::class);
+		$type = $transformer->deserialize($data);
+	}
+
+	public function testDeserializeInvalidDataAllowProxy(): void {
+		$transformer = new EquipmentTypeTransformer();
+
+		$id = 42;
+		$name = 'laser scalpel';
+		$requires_training = TRUE;
+		$charge_rate = "2.50";
+		$charge_policy_id = ChargePolicy::PER_USE;
+
+		$data = [
+			'id' => $id,
+			'name' => $name,
+			'requires_training' => $requires_training,
+			'charge_rate' => $charge_rate,
+			'charge_policy_id' => $charge_policy_id
 		];
 
 		$this->expectException(InvalidArgumentException::class);
@@ -123,13 +155,15 @@ final class EquipmentTypeTransformerTest extends TestCase {
 		$charge_rate = "2.50";
 		$charge_policy_id = ChargePolicy::PER_USE;
 		$charge_policy = ChargePolicy::name_for_policy($charge_policy_id);
+		$allow_proxy = true;
 
 		$type = (new EquipmentType())
 			->set_id($id)
 			->set_name($name)
 			->set_requires_training($requires_training)
 			->set_charge_rate($charge_rate)
-			->set_charge_policy_id($charge_policy_id);
+			->set_charge_policy_id($charge_policy_id)
+			->set_allow_proxy($allow_proxy);
 
 		$data = $transformer->serialize($type, true);
 
@@ -146,5 +180,7 @@ final class EquipmentTypeTransformerTest extends TestCase {
 		self::assertEquals($charge_policy_id, $data['charge_policy_id']);
 		self::assertArrayHasKey('charge_policy', $data);
 		self::assertEquals($charge_policy, $data['charge_policy']);
+		self::assertArrayHasKey('allow_proxy', $data);
+		self::assertEquals($allow_proxy, $data['allow_proxy']);
 	}
 }

--- a/test/Transform/LocationTransformerTest.php
+++ b/test/Transform/LocationTransformerTest.php
@@ -24,7 +24,7 @@ final class LocationTransformerTest extends TestCase {
 
 		self::assertNotNull($location);
 		self::assertNull($location->id());
-		self::assertEquals($name, $location->name());
+		self::assertEquals(htmlspecialchars($name), $location->name());
 	}
 
 	public function testDeserializeInvalidDataUserID(): void {

--- a/test/Transform/LoggedEventTransformerTest.php
+++ b/test/Transform/LoggedEventTransformerTest.php
@@ -94,7 +94,8 @@ final class LoggedEventTransformerTest extends TestCase {
 			->set_name($name)
 			->set_requires_training($requires_training)
 			->set_charge_policy_id($event_policy_id)
-			->set_charge_rate('2.00');
+			->set_charge_rate('2.00')
+			->set_allow_proxy(false);
 
 		self::$type = $model->create($type);
 
@@ -137,6 +138,8 @@ final class LoggedEventTransformerTest extends TestCase {
 		// deprovision an equipment type in the db
 		$model = new EquipmentTypeModel($config);
 		$model->delete(self::$type->id());
+
+		parent::tearDownAfterClass();
 	}
 
 	public function testSerialize(): void {

--- a/test/Transform/LoggedEventTransformerTest.php
+++ b/test/Transform/LoggedEventTransformerTest.php
@@ -145,7 +145,7 @@ final class LoggedEventTransformerTest extends TestCase {
 		$id = 42;
 		$time = '2020-05-31 10:46:34';
 		$card_id = 1928376451092837465;
-		$type_id = LoggedEventType::SUCESSFUL_AUTHENTICATION;
+		$type_id = LoggedEventType::SUCCESSFUL_AUTHENTICATION;
 
 		$event = (new LoggedEvent())
 			->set_id($id)

--- a/test/Transform/PaymentTransformerTest.php
+++ b/test/Transform/PaymentTransformerTest.php
@@ -54,6 +54,8 @@ final class PaymentTransformerTest extends TestCase {
 		// deprovision user from the db
 		$model = new UserModel($config);
 		$model->delete(self::$user->id());
+
+		parent::tearDownAfterClass();
 	}
 
 	public function testDeserialize(): void {

--- a/test/Transform/UserTransformerTest.php
+++ b/test/Transform/UserTransformerTest.php
@@ -23,7 +23,7 @@ final class UserTransformerTest extends TestCase {
 	private static $type;
 
 	public static function setUpBeforeClass(): void {
-		parent::setUp();
+		parent::setUpBeforeClass();
 
 		// provision an equipment type in the db
 		$model = new EquipmentTypeModel(Config::config());
@@ -35,7 +35,8 @@ final class UserTransformerTest extends TestCase {
 		$type = (new EquipmentType())
 			->set_name($name)
 			->set_requires_training($requires_training)
-			->set_charge_policy_id($charge_policy_id);
+			->set_charge_policy_id($charge_policy_id)
+			->set_allow_proxy(false);
 
 		self::$type = $model->create($type);
 	}
@@ -44,6 +45,8 @@ final class UserTransformerTest extends TestCase {
 		// deprovision an equipment type in the db
 		$model = new EquipmentTypeModel(Config::config());
 		$model->delete(self::$type->id());
+
+		parent::tearDownAfterClass();
 	}
 
 	public function testDeserialize(): void {


### PR DESCRIPTION
This PR if accepted fixes a number of code rot issues that prevented the unit tests from running out of the box. There's a lot here but one of the biggest issues was the drift in the database from the 2.7.0 schema present in the master branch of https://github.com/Bucknell-ECE/PortalBox-database. I have provided a PR to backfill some of the missing schema changes indicated by this code base:

- https://github.com/Bucknell-ECE/PortalBox-database/pull/3

and have a branch

- https://github.com/tkegan/PortalBox-database/tree/feature/schema-2.9.0-track-equipment-ip

for the rest pending confirmation of some details. This branch should therefore wait until those database changes are accepted.