### PR TITLE
cleanup: simplify code by dropping @package annotation

### DIFF
--- a/src/Entity/APIKey.php
+++ b/src/Entity/APIKey.php
@@ -7,8 +7,6 @@ use InvalidArgumentException;
 /**
  * APIKey represents a token that can be used to authenticate to the REST API
  * without establishing a User Session
- * 
- * @package Portalbox\Entity
  */
 class APIKey extends AbstractEntity {
 

--- a/src/Entity/AbstractEntity.php
+++ b/src/Entity/AbstractEntity.php
@@ -5,8 +5,6 @@ namespace Portalbox\Entity;
 /**
  * AbstractEntity is the base class for the other entities in the system. It
  * "abstracts out" common functionality.
- *
- * @package Portalbox\Entity
  */
 class AbstractEntity {
 	/**

--- a/src/Entity/Card.php
+++ b/src/Entity/Card.php
@@ -5,8 +5,6 @@ namespace Portalbox\Entity;
 /**
  * Cards come in a number of types and when presented to a portalbox, the
  * portalbox takes action based on the card type.
- * 
- * @package Portalbox\Entity
  */
 interface Card {
 

--- a/src/Entity/CardType.php
+++ b/src/Entity/CardType.php
@@ -7,8 +7,6 @@ use ReflectionClass;
 /**
  * CardType represents the kind of an equipment activation card... the IoT
  * application decides what to do based on CardType when presented with a card.
- * 
- * @package Portalbox\Entity
  */
 class CardType {
 	/** This card type can be used to shutdown Portalboxes */
@@ -68,7 +66,7 @@ class CardType {
 
 	/**
 	 * Get the name for the card type
-	 * 
+	 *
 	 * @param int type_id - the policy id to check
 	 * @return string - name for the event type
 	 */

--- a/src/Entity/Charge.php
+++ b/src/Entity/Charge.php
@@ -5,8 +5,6 @@ namespace Portalbox\Entity;
 /**
  * Charge represents a charge to a user for use of equipment in the
  * portalbox network
- * 
- * @package Portalbox\Entity
  */
 class Charge extends AbstractEntity {
 

--- a/src/Entity/ChargePolicy.php
+++ b/src/Entity/ChargePolicy.php
@@ -7,8 +7,6 @@ namespace Portalbox\Entity;
  * charge when an activation session ends... as a stored procedure in the
  * database does the calculation, ChargePolicies occupy a privileged role
  * and are difficult to change so they are predefined
- *
- * @package Portalbox\Entity
  */
 class ChargePolicy {
 	/** This charge type indicates that a charge has been manually adjusted. */

--- a/src/Entity/Equipment.php
+++ b/src/Entity/Equipment.php
@@ -6,8 +6,6 @@ use InvalidArgumentException;
 
 /**
  * Equipment represents a machine connected to a Portalbox.
- *
- * @package Portalbox\Entity
  */
 class Equipment extends AbstractEntity {
 

--- a/src/Entity/EquipmentType.php
+++ b/src/Entity/EquipmentType.php
@@ -6,8 +6,6 @@ use InvalidArgumentException;
 
 /**
  * Equipment Type binds policy to equipment of the same type
- *
- * @package Portalbox\Entity
  */
 class EquipmentType extends AbstractEntity {
 

--- a/src/Entity/Location.php
+++ b/src/Entity/Location.php
@@ -6,12 +6,10 @@ use InvalidArgumentException;
 
 /**
  * Location represents a somewhere Equipment is located.
- * 
+ *
  * While a Makerspace might have only a single location, implementors like
  * a University might have multiple locations across campus with equipment
  * that they wish to outfit with Portal boxes as a single campus wide system.
- * 
- * @package Portalbox\Entity
  */
 class Location extends AbstractEntity {
 

--- a/src/Entity/LoggedEvent.php
+++ b/src/Entity/LoggedEvent.php
@@ -4,8 +4,6 @@ namespace Portalbox\Entity;
 
 /**
  * LoggedEvent represents one Event in the event log
- * 
- * @package Portalbox\Entity
  */
 class LoggedEvent extends AbstractEntity {
 
@@ -22,7 +20,7 @@ class LoggedEvent extends AbstractEntity {
 	 * @var int
 	 */
 	protected $type_id;
-	
+
 	/**
 	 * The id of the card which triggered this event
 	 *
@@ -32,7 +30,7 @@ class LoggedEvent extends AbstractEntity {
 
 	/**
 	 * The card which triggered this event
-	 * 
+	 *
 	 * @var Card|null
 	 */
 	protected $card;
@@ -46,7 +44,7 @@ class LoggedEvent extends AbstractEntity {
 
 	/**
 	 * The user whose card which triggered this event
-	 * 
+	 *
 	 * @var User|null
 	 */
 	protected $user;
@@ -60,22 +58,22 @@ class LoggedEvent extends AbstractEntity {
 
 	/**
 	 * The name of the equipment which reported this event
-	 * 
+	 *
 	 * @var Equipment|null
 	 */
 	protected $equipment;
 
-	
+
 	/**
 	 * The id of the equipment type for this event
-	 * 
+	 *
 	 * @var int
 	 */
 	private $equipment_type_id;
 
 	/**
 	 * The name of the equipment type for this event
-	 * 
+	 *
 	 * @var string
 	 */
 	private $equipment_type;
@@ -154,7 +152,7 @@ class LoggedEvent extends AbstractEntity {
 	// a convenience method... see Model\Entity\LoggedEventModel ;)
 	/**
 	 * Get the name of the equipment which reported this event
-	 * 
+	 *
 	 * @return string - the name of the equipment
 	 */
 	public function equipment_name() : ?string {
@@ -262,7 +260,7 @@ class LoggedEvent extends AbstractEntity {
 	// a convenience method... see Model\Entity\LoggedEventModel ;)
 	/**
 	 * Get the name of the user whose action triggered this event
-	 * 
+	 *
 	 * @return string - the name of the user
 	 */
 	public function user_name() : ?string {
@@ -303,7 +301,7 @@ class LoggedEvent extends AbstractEntity {
 	/**
 	 * Get the name of the location where the equipment which triggerd this
 	 * event is located
-	 * 
+	 *
 	 * @return string - the name of the location
 	 */
 	public function location_name() : ?string {

--- a/src/Entity/LoggedEventType.php
+++ b/src/Entity/LoggedEventType.php
@@ -4,8 +4,6 @@ namespace Portalbox\Entity;
 
 /**
  * LoggedEventType represents the type of a log event.
- *
- * @package Portalbox\Entity
  */
 class LoggedEventType {
 	/**

--- a/src/Entity/Payment.php
+++ b/src/Entity/Payment.php
@@ -5,8 +5,6 @@ namespace Portalbox\Entity;
 /**
  * Payment represents a payment made by the user to the operator of the
  * portalbox network
- *
- * @package Portalbox\Entity
  */
 class Payment extends AbstractEntity {
 

--- a/src/Entity/Permission.php
+++ b/src/Entity/Permission.php
@@ -4,8 +4,6 @@ namespace Portalbox\Entity;
 
 /**
  * Permission represents a permission which a particular role may have
- *
- * @package Portalbox\Entity
  */
 class Permission {
 	/** Users with this permission can create API keys */

--- a/src/Entity/ProxyCard.php
+++ b/src/Entity/ProxyCard.php
@@ -5,8 +5,6 @@ namespace Portalbox\Entity;
 /**
  * Cards come in a number of types and when presented to a portalbox, the
  * portalbox shutsdown when presented with cards of this type.
- * 
- * @package Portalbox\Entity
  */
 class ProxyCard extends AbstractEntity implements Card {
 

--- a/src/Entity/Role.php
+++ b/src/Entity/Role.php
@@ -9,8 +9,6 @@ use InvalidArgumentException;
  *
  * Every user is assigned a role and thus has a set of permissions restricting
  * what they can do in the web portal.
- *
- * @package Portalbox\Entity
  */
 class Role extends AbstractEntity {
 

--- a/src/Entity/ShutdownCard.php
+++ b/src/Entity/ShutdownCard.php
@@ -5,8 +5,6 @@ namespace Portalbox\Entity;
 /**
  * Cards come in a number of types and when presented to a portalbox, the
  * portalbox shutsdown when presented with cards of this type.
- * 
- * @package Portalbox\Entity
  */
 class ShutdownCard extends AbstractEntity implements Card {
 

--- a/src/Entity/TrainingCard.php
+++ b/src/Entity/TrainingCard.php
@@ -5,8 +5,6 @@ namespace Portalbox\Entity;
 /**
  * Cards come in a number of types and when presented to a portalbox, the
  * portalbox shuts down when presented with cards of this type.
- *
- * @package Portalbox\Entity
  */
 class TrainingCard extends AbstractEntity implements Card {
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -4,11 +4,9 @@ namespace Portalbox\Entity;
 
 /**
  * User represents a User in the system.
- * 
+ *
  *	Typically this class is used by requesting the authenticated user instance
  *	from the Session which will be an instance of this class
- * 
- * @package Portalbox\Entity
  */
 class User extends AbstractEntity {
 	/**
@@ -41,14 +39,14 @@ class User extends AbstractEntity {
 
 	/**
 	 * The role of the user
-	 * 
+	 *
 	 * @var Role|null
 	 */
 	protected $role;
 
 	/**
 	 * Whether this user is active ie can login
-	 * 
+	 *
 	 * Log entries have a reference to the user so we can't delete users instead
 	 * we change them to inactive
 	 *
@@ -146,7 +144,7 @@ class User extends AbstractEntity {
 
 	/**
 	 * Get the user's role's name
-	 * 
+	 *
 	 * @return string - the name of the user's role
 	 */
 	public function role_name() : string {

--- a/src/Entity/UserCard.php
+++ b/src/Entity/UserCard.php
@@ -5,8 +5,6 @@ namespace Portalbox\Entity;
 /**
  * Cards come in a number of types and when presented to a portalbox, the
  * portalbox shutsdown when presented with cards of this type.
- *
- * @package Portalbox\Entity
  */
 class UserCard extends AbstractEntity implements Card {
 

--- a/src/Model/APIKeyModel.php
+++ b/src/Model/APIKeyModel.php
@@ -10,8 +10,6 @@ use PDO;
 
 /**
  * APIKeyModel is our bridge between the database and higher level Entities.
- * 
- * @package Portalbox\Model
  */
 class APIKeyModel extends AbstractModel {
 	/**
@@ -121,7 +119,7 @@ class APIKeyModel extends AbstractModel {
 
 	/**
 	 * Search for an APIKey or APIKeys
-	 * 
+	 *
 	 * @param APIKeyQuery query - the search query to perform
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return APIKey[]|null - a list of api keys which match the search query
@@ -148,7 +146,7 @@ class APIKeyModel extends AbstractModel {
 		if(NULL !== $query->token()) {
 			$statement->bindValue(':token', $query->token());
 		}
-		
+
 		if($statement->execute()) {
 			$data = $statement->fetchAll(PDO::FETCH_ASSOC);
 			if(FALSE !== $data) {

--- a/src/Model/AbstractModel.php
+++ b/src/Model/AbstractModel.php
@@ -6,13 +6,11 @@ use Portalbox\Config;
 
 /**
  * Abstract model is the common foundation on which our object models are built.
- * 
- * @package Portalbox\Model
  */
 class AbstractModel {
 	/**
 	 * The configuration to use
-	 * 
+	 *
 	 * @var Config
 	 */
 	private $configuration;

--- a/src/Model/CardModel.php
+++ b/src/Model/CardModel.php
@@ -20,8 +20,6 @@ use PDO;
 
 /**
  * CardModel is our bridge between the database and higher level Entities.
- * 
- * @package Portalbox\Model
  */
 class CardModel extends AbstractModel {
 	/**
@@ -168,7 +166,7 @@ class CardModel extends AbstractModel {
 
 	/**
 	 * Search for Cards
-	 * 
+	 *
 	 * @param CardQuery|null query - the search query to perform
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Card[]|null - a list of equipment which match the search query
@@ -226,9 +224,9 @@ class CardModel extends AbstractModel {
 					function ($e) use ($equipment_type_id) {
 						return $e->id() == $equipment_type_id;
 					});
-				
+
 				$equipment_type = array_pop($equipment_type);
-				
+
 				return $card = (new TrainingCard())
 					->set_id($data['id'])
 					->set_equipment_type_id($data['equipment_type_id'])
@@ -242,7 +240,7 @@ class CardModel extends AbstractModel {
 					});
 
 				$user = array_pop($user);
-				
+
 				return(new UserCard())
 					->set_id($data['id'])
 					->set_user_id($data['user_id'])
@@ -263,7 +261,7 @@ class CardModel extends AbstractModel {
 		$r_model = new RoleModel($this->configuration());
 
 		$u_query = new UserQuery();
-		
+
 		$equipment_types = $e_model->search();
 		$users = $u_model->search($u_query);
 		$roles = $r_model->search();

--- a/src/Model/ChargeModel.php
+++ b/src/Model/ChargeModel.php
@@ -15,8 +15,6 @@ use PDO;
 
 /**
  * ChargeModel is our bridge between the database and higher level Entities.
- *
- * @package Portalbox\Model
  */
 class ChargeModel extends AbstractModel {
 	/**

--- a/src/Model/EquipmentModel.php
+++ b/src/Model/EquipmentModel.php
@@ -11,8 +11,6 @@ use PDO;
 
 /**
  * EquipmentModel is our bridge between the database and higher level Entities.
- *
- * @package Portalbox\Model
  */
 class EquipmentModel extends AbstractModel {
 

--- a/src/Model/EquipmentTypeModel.php
+++ b/src/Model/EquipmentTypeModel.php
@@ -9,8 +9,6 @@ use PDO;
 
 /**
  * EquipmentTypeModel is our bridge between the database and higher level Entities.
- * 
- * @package Portalbox\Model
  */
 class EquipmentTypeModel extends AbstractModel {
 	/**
@@ -112,7 +110,7 @@ class EquipmentTypeModel extends AbstractModel {
 
 	/**
 	 * Search for equipment types
-	 * 
+	 *
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Location[]|null - a list of locations
 	 */

--- a/src/Model/LocationModel.php
+++ b/src/Model/LocationModel.php
@@ -9,8 +9,6 @@ use PDO;
 
 /**
  * LocationModel is our bridge between the database and higher level Entities.
- * 
- * @package Portalbox\Model
  */
 class LocationModel extends AbstractModel {
 	/**
@@ -104,7 +102,7 @@ class LocationModel extends AbstractModel {
 
 	/**
 	 * Search for locations
-	 * 
+	 *
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Location[]|null - a list of locations
 	 */

--- a/src/Model/LoggedEventModel.php
+++ b/src/Model/LoggedEventModel.php
@@ -12,8 +12,6 @@ use PDO;
 
 /**
  * LoggedEventModel is our bridge between the database and higher level Entities.
- * 
- * @package Portalbox\Model
  */
 class LoggedEventModel extends AbstractModel {
 
@@ -26,14 +24,14 @@ class LoggedEventModel extends AbstractModel {
 	 */
 	public function read(int $id) : ?LoggedEvent {
 		$connection = $this->configuration()->readonly_db_connection();
-		$sql = 'SELECT el.id, el.time, el.event_type_id, el.card_id, c.type_id AS card_type_id, el.equipment_id, e.name AS equipment_name, l.name AS location_name, u.id AS user_id, IF(c.type_id = 4, u.name, UPPER(ct.name)) as user_name 
-		FROM log AS el 
-		INNER JOIN equipment AS e ON el.equipment_id = e.id 
-		INNER JOIN locations AS l ON e.location_id = l.id 
-		INNER JOIN cards AS c ON el.card_id = c.id 
+		$sql = 'SELECT el.id, el.time, el.event_type_id, el.card_id, c.type_id AS card_type_id, el.equipment_id, e.name AS equipment_name, l.name AS location_name, u.id AS user_id, IF(c.type_id = 4, u.name, UPPER(ct.name)) as user_name
+		FROM log AS el
+		INNER JOIN equipment AS e ON el.equipment_id = e.id
+		INNER JOIN locations AS l ON e.location_id = l.id
+		INNER JOIN cards AS c ON el.card_id = c.id
 		INNER JOIN card_types AS ct ON c.type_id = ct.id
-		LEFT JOIN users_x_cards AS uxc ON el.card_id = uxc.card_id 
-		LEFT JOIN users AS u ON u.id = uxc.user_id 
+		LEFT JOIN users_x_cards AS uxc ON el.card_id = uxc.card_id
+		LEFT JOIN users AS u ON u.id = uxc.user_id
 		WHERE el.id = :id';
 		$query = $connection->prepare($sql);
 		$query->bindValue(':id', $id, PDO::PARAM_INT);
@@ -62,14 +60,14 @@ class LoggedEventModel extends AbstractModel {
 		}
 
 		$connection = $this->configuration()->readonly_db_connection();
-		$sql = 'SELECT el.id, el.time, el.event_type_id, el.card_id, c.type_id AS card_type_id, el.equipment_id, e.name AS equipment_name, et.id AS equipment_type_id, et.name AS equipment_type, l.name AS location_name, u.id AS user_id, IF(c.type_id = 4, u.name, UPPER(ct.name)) as user_name 
-		FROM log AS el 
-		INNER JOIN equipment AS e ON el.equipment_id = e.id 
-		INNER JOIN equipment_types AS et ON e.type_id = et.id 
-		INNER JOIN locations AS l ON e.location_id = l.id 
-		INNER JOIN cards AS c ON el.card_id = c.id 
+		$sql = 'SELECT el.id, el.time, el.event_type_id, el.card_id, c.type_id AS card_type_id, el.equipment_id, e.name AS equipment_name, et.id AS equipment_type_id, et.name AS equipment_type, l.name AS location_name, u.id AS user_id, IF(c.type_id = 4, u.name, UPPER(ct.name)) as user_name
+		FROM log AS el
+		INNER JOIN equipment AS e ON el.equipment_id = e.id
+		INNER JOIN equipment_types AS et ON e.type_id = et.id
+		INNER JOIN locations AS l ON e.location_id = l.id
+		INNER JOIN cards AS c ON el.card_id = c.id
 		INNER JOIN card_types AS ct ON c.type_id = ct.id
-		LEFT JOIN users_x_cards AS uxc ON el.card_id = uxc.card_id 
+		LEFT JOIN users_x_cards AS uxc ON el.card_id = uxc.card_id
 		LEFT JOIN users AS u ON u.id = uxc.user_id';
 
 		$where_clause_fragments = array();
@@ -109,7 +107,7 @@ class LoggedEventModel extends AbstractModel {
 		foreach($parameters as $k => $v) {
 			$statement->bindValue($k, $v);
 		}
-		
+
 		if($statement->execute()) {
 			$data = $statement->fetchAll(PDO::FETCH_ASSOC);
 			if(FALSE !== $data) {

--- a/src/Model/PaymentModel.php
+++ b/src/Model/PaymentModel.php
@@ -10,8 +10,6 @@ use PDO;
 
 /**
  * PaymentModel is our bridge between the database and higher level Entities.
- * 
- * @package Portalbox\Model
  */
 class PaymentModel extends AbstractModel {
 	/**
@@ -109,7 +107,7 @@ class PaymentModel extends AbstractModel {
 
 	/**
 	 * Search for Payments
-	 * 
+	 *
 	 * @param PaymentQuery query - the search query to perform
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Payment[]|null - a list of payments which match the search query

--- a/src/Model/RoleModel.php
+++ b/src/Model/RoleModel.php
@@ -9,8 +9,6 @@ use PDO;
 
 /**
  * RoleModel is our bridge between the database and higher level Entities.
- * 
- * @package Portalbox\Model
  */
 class RoleModel extends AbstractModel {
 	/**
@@ -33,12 +31,12 @@ class RoleModel extends AbstractModel {
 			if($statement->execute()) {
 				// Add in permissions
 				$role_id = $connection->lastInsertId('roles_id_seq');
-	
+
 				$permissions = $role->permissions();
-	
+
 				$sql = 'INSERT INTO roles_x_permissions (role_id, permission_id) VALUES (:role_id, :permission_id)';
 				$statement = $connection->prepare($sql);
-	
+
 				foreach($permissions as $permission_id) {
 					$statement->bindValue(':role_id', $role_id, PDO::PARAM_INT);
 					$statement->bindValue(':permission_id', $permission_id, PDO::PARAM_INT);
@@ -61,7 +59,7 @@ class RoleModel extends AbstractModel {
 		} else {
 			throw new DatabaseException($connection->errorInfo()[2]);
 		}
-		
+
 	}
 
 	/**
@@ -79,7 +77,7 @@ class RoleModel extends AbstractModel {
 		if($statement->execute()) {
 			if($data = $statement->fetch(PDO::FETCH_ASSOC)) {
 				$role = $this->buildRoleFromArray($data);
-				
+
 				$sql = 'SELECT permission_id FROM roles_x_permissions WHERE role_id = :role_id';
 				$statement = $connection->prepare($sql);
 				$statement->bindValue(':role_id', $data['id'], PDO::PARAM_INT);
@@ -128,10 +126,10 @@ class RoleModel extends AbstractModel {
 				$unchanged_permissions = array_intersect($old_permissions, $permissions);
 				$added_permissions = array_diff($permissions, $unchanged_permissions);
 				$removed_permissions = array_diff($old_permissions, $unchanged_permissions);
-	
+
 				$sql = 'INSERT INTO roles_x_permissions (role_id, permission_id) VALUES (:role_id, :permission_id)';
 				$statement = $connection->prepare($sql);
-	
+
 				foreach($added_permissions as $permission_id) {
 					$statement->bindValue(':role_id', $role_id, PDO::PARAM_INT);
 					$statement->bindValue(':permission_id', $permission_id, PDO::PARAM_INT);
@@ -196,7 +194,7 @@ class RoleModel extends AbstractModel {
 
 	/**
 	 * Search for Roles
-	 * 
+	 *
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Role[]|null - a list of role which match the search query
 	 */

--- a/src/Model/UserModel.php
+++ b/src/Model/UserModel.php
@@ -11,8 +11,6 @@ use PDO;
 
 /**
  * UserModel is our bridge between the database and higher level Entities.
- * 
- * @package Portalbox\Model
  */
 class UserModel extends AbstractModel {
 	/**
@@ -37,12 +35,12 @@ class UserModel extends AbstractModel {
 			if($statement->execute()) {
 				// Add in authorizations
 				$user_id = $connection->lastInsertId('users_id_seq');
-	
+
 				$authorizations = $user->authorizations();
-	
+
 				$sql = 'INSERT INTO authorizations (user_id, equipment_type_id) VALUES (:user_id, :equipment_type_id)';
 				$statement = $connection->prepare($sql);
-	
+
 				foreach($authorizations as $equipment_type_id) {
 					$statement->bindValue(':user_id', $user_id, PDO::PARAM_INT);
 					$statement->bindValue(':equipment_type_id', $equipment_type_id, PDO::PARAM_INT);
@@ -131,7 +129,7 @@ class UserModel extends AbstractModel {
 					->set_comment($user->comment())
 					->set_is_active($user->is_active())
 					->set_role_id($user->role()->id());
-				
+
 				// Authorizations... There are three cases:
 				//	1) Authorizations which were removed -> delete
 				//	2) Authorizations which were added -> insert
@@ -140,10 +138,10 @@ class UserModel extends AbstractModel {
 				$unchanged_authorizations = array_intersect($old_authorizations, $authorizations);
 				$added_authorizations = array_diff($authorizations, $unchanged_authorizations);
 				$removed_authorizations = array_diff($old_authorizations, $unchanged_authorizations);
-	
+
 				$sql = 'INSERT INTO authorizations (user_id, equipment_type_id) VALUES (:user_id, :equipment_type_id)';
 				$statement = $connection->prepare($sql);
-	
+
 				foreach($added_authorizations as $equipment_type_id) {
 					$statement->bindValue(':user_id', $user_id, PDO::PARAM_INT);
 					$statement->bindValue(':equipment_type_id', $equipment_type_id, PDO::PARAM_INT);
@@ -204,7 +202,7 @@ class UserModel extends AbstractModel {
 
 	/**
 	 * Search for a User or Users
-	 * 
+	 *
 	 * @param UserQuery query - the search query to perform
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return User[]|null - a list of users which match the search query

--- a/src/Query/APIKeyQuery.php
+++ b/src/Query/APIKeyQuery.php
@@ -4,8 +4,6 @@ namespace Portalbox\Query;
 
 /**
  * APIKeyQuery Presents a standard interface for APIKey search queries
- * 
- * @package Portalbox\Query
  */
 class APIKeyQuery {
 	/**
@@ -21,7 +19,7 @@ class APIKeyQuery {
 	 * @return string|null - the token for which to search
 	 */
 	public function token() : ?string {
-		
+
 		return $this->token;
 	}
 
@@ -32,7 +30,7 @@ class APIKeyQuery {
 	 * @return self
 	 */
 	public function set_token(string $token) : self {
-		
+
 		$this->token = $token;
 		return $this;
 	}

--- a/src/Query/CardQuery.php
+++ b/src/Query/CardQuery.php
@@ -4,8 +4,6 @@ namespace Portalbox\Query;
 
 /**
  * CardQuery presents a standard interface for Card search queries
- * 
- * @package Portalbox\Query
  */
 class CardQuery {
 	/**
@@ -24,7 +22,7 @@ class CardQuery {
 
 	/**
 	 * Find cards for this id
-	 * 
+	 *
 	 * @var int
 	 */
 	protected $id;
@@ -71,7 +69,7 @@ class CardQuery {
 
 	/**
 	 * Get the card id
-	 * 
+	 *
 	 * @return int - the card id
 	 */
 	public function id() : ?int  {
@@ -80,7 +78,7 @@ class CardQuery {
 
 	/**
 	 * Set the card id
-	 * 
+	 *
 	 * @param int id - the card id
 	 * @return self
 	 */

--- a/src/Query/ChargeQuery.php
+++ b/src/Query/ChargeQuery.php
@@ -4,8 +4,6 @@ namespace Portalbox\Query;
 
 /**
  * ChargeQuery presents a standard interface for Charge search queries
- *
- * @package Portalbox\Query
  */
 class ChargeQuery {
 	/**

--- a/src/Query/EquipmentQuery.php
+++ b/src/Query/EquipmentQuery.php
@@ -4,8 +4,6 @@ namespace Portalbox\Query;
 
 /**
  * EquipmentQuery presents a standard interface for Equipment search queries
- * 
- * @package Portalbox\Query
  */
 class EquipmentQuery {
 	/**

--- a/src/Query/LoggedEventQuery.php
+++ b/src/Query/LoggedEventQuery.php
@@ -4,8 +4,6 @@ namespace Portalbox\Query;
 
 /**
  * LoggedEventQuery presents a standard interface for LoggedEvent search queries
- * 
- * @package Portalbox\Query
  */
 class LoggedEventQuery {
 	/**
@@ -45,7 +43,7 @@ class LoggedEventQuery {
 
 	/**
 	 * Find log events of a giben equipment type
-	 * 
+	 *
 	 * @var int
 	 */
 	protected $equipment_type_id;
@@ -152,7 +150,7 @@ class LoggedEventQuery {
 
 	/**
 	 * Get the equipment type id
-	 * 
+	 *
 	 * @return int - the equipment type id
 	 */
 	public function equipment_type_id() : ?int {
@@ -161,7 +159,7 @@ class LoggedEventQuery {
 
 	/**
 	 * Set the equipment type id
-	 * 
+	 *
 	 * @param int equipment_type_id - the equipment type id
 	 * @return self
 	 */

--- a/src/Query/PaymentQuery.php
+++ b/src/Query/PaymentQuery.php
@@ -4,8 +4,6 @@ namespace Portalbox\Query;
 
 /**
  * PaymentQuery presents a standard interface for Charge search queries
- * 
- * @package Portalbox\Query
  */
 class PaymentQuery {
 	/**

--- a/src/Query/UserQuery.php
+++ b/src/Query/UserQuery.php
@@ -4,8 +4,6 @@ namespace Portalbox\Query;
 
 /**
  * UserQuery presents a standard interface for User search queries
- * 
- * @package Portalbox\Query
  */
 class UserQuery {
 	/**
@@ -17,42 +15,42 @@ class UserQuery {
 
 	/**
 	 * The name of the user for which to search
-	 * 
+	 *
 	 * @var string
 	 */
 	protected $name;
 
 	/**
 	 * The comment for the user to search for
-	 * 
+	 *
 	 * @var string
 	 */
 	protected $comment;
 
 	/**
 	 * The id of the user for which to search
-	 * 
+	 *
 	 * @var int
 	 */
 	protected $id;
 
 	/**
 	 * Equipment id to find authorized users for
-	 * 
+	 *
 	 * @var int
 	 */
 	protected $equipment_id;
 
 	/**
 	 * Int for determining if inactive users should be included
-	 * 
+	 *
 	 * @var int
 	 */
 	protected $include_inactive;
 
 	/**
 	 * Int for role id to search by
-	 * 
+	 *
 	 * @var int
 	 */
 	protected $role_id;
@@ -79,7 +77,7 @@ class UserQuery {
 
 	/**
 	 * Get the name of the user for which to search
-	 * 
+	 *
 	 * @return string|null - the name of the user for which to search
 	 */
 	public function name() : ?string {
@@ -89,7 +87,7 @@ class UserQuery {
 	/**
 	 * Set the name of the user for which to search
 	 *
-	 * @param string email - the name of the user for which to search 
+	 * @param string email - the name of the user for which to search
 	 * @return self
 	 */
 	public function set_name(string $name) : self {
@@ -99,7 +97,7 @@ class UserQuery {
 
 	/**
 	 * Get the comment of the user for which to search
-	 * 
+	 *
 	 * @return string|null
 	 */
 	public function comment() : ?string {
@@ -108,7 +106,7 @@ class UserQuery {
 	/**
 	 * Set the comment of the user for which to search
 	 *
-	 * @param string comment 
+	 * @param string comment
 	 * @return self
 	 */
 	public function set_comment(string $comment) : self {
@@ -118,7 +116,7 @@ class UserQuery {
 
 	/**
 	 * Get the equipment id to search for authorized users with
-	 * 
+	 *
 	 * @return int|null
 	 */
 	public function equipment_id() : ?int {
@@ -127,7 +125,7 @@ class UserQuery {
 
 	/**
 	 * Set the equipment id to search for authorized users with
-	 * 
+	 *
 	 * @param int equipment id
 	 * @return self
 	 */

--- a/src/ResponseHandler.php
+++ b/src/ResponseHandler.php
@@ -12,8 +12,6 @@ use Portalbox\Transform\OutputTransformer;
  * be subclassed to control the fields exposed in the response. Subclasses
  * may override json_encode_entity, json_encode_list, get_cvs_header,
  * list_item_to_array.
- *
- * @package Portalbox\Transformer
  */
 class ResponseHandler {
 

--- a/src/Transform/APIKeyTransformer.php
+++ b/src/Transform/APIKeyTransformer.php
@@ -8,13 +8,11 @@ use Portalbox\Entity\APIKey;
 /**
  * APIKeyTransformer is our bridge between dictionary representations and
  * APIKey entity instances.
- * 
- * @package Portalbox\Transform
  */
 class APIKeyTransformer implements InputTransformer, OutputTransformer {
 	/**
 	 * Deserialize an APIKey entity object from a dictionary
-	 * 
+	 *
 	 * @param array data - a dictionary representing a Payment
 	 * @return APIKey - a valid entity object based on the data specified
 	 * @throws InvalidArgumentException if a require field is not specified
@@ -31,7 +29,7 @@ class APIKeyTransformer implements InputTransformer, OutputTransformer {
 	/**
 	 * Called to serialize a APIKey entity instance to a dictionary
 	 *
-	 * @param bool $traverse - traverse the object graph if true, otherwise 
+	 * @param bool $traverse - traverse the object graph if true, otherwise
 	 *      may substitute flattened representations where appropriate.
 	 * @return array -  a dictionary whose values are null, string, int, float
 	 *      dictionaries, or arrays with the compound types having the same
@@ -58,7 +56,7 @@ class APIKeyTransformer implements InputTransformer, OutputTransformer {
 	 * Called to get the column headers for a tabular output format eg csv.
 	 * The column count should match the number of fields in an array returned
 	 * by serialize() when $traverse is false
-	 * 
+	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
 	public function get_column_headers() : array {

--- a/src/Transform/AuthorizationsTransformer.php
+++ b/src/Transform/AuthorizationsTransformer.php
@@ -12,13 +12,11 @@ use Portalbox\Model\EquipmentTypeModel;
 /**
  * AuthorizationsTransformer is our bridge between dictionary representations
  * of Authorizations lists and arrays of equipment ids
- * 
- * @package Portalbox\Transform
  */
 class AuthorizationsTransformer implements InputTransformer {
 	/**
 	 * Deserialize an Authorizations entity object from a dictionary
-	 * 
+	 *
 	 * @param array data - a dictionary representing an Authorizations list
 	 * @return array<int> - a list of authorization ids
 	 * @throws InvalidArgumentException if a required field is not specified

--- a/src/Transform/CardTransformer.php
+++ b/src/Transform/CardTransformer.php
@@ -20,13 +20,11 @@ use Portalbox\Model\UserModel;
 /**
  * CardTransformer is our bridge between dictionary representations and
  * Card entity instances.
- * 
- * @package Portalbox\Transform
  */
 class CardTransformer implements InputTransformer, OutputTransformer {
 	/**
 	 * Deserialize a Card entity object from a dictionary
-	 * 
+	 *
 	 * @param array data - a dictionary representing a Card
 	 * @return Card - a valid entity object based on the data specified
 	 * @throws InvalidArgumentException if a require field is not specified
@@ -72,7 +70,7 @@ class CardTransformer implements InputTransformer, OutputTransformer {
 	/**
 	 * Called to serialize Card entity instance to a dictionary
 	 *
-	 * @param bool $traverse - traverse the object graph if true, otherwise 
+	 * @param bool $traverse - traverse the object graph if true, otherwise
 	 *      may substitute flattened representations where appropriate.
 	 * @return array -  a dictionary whose values are null, string, int, float
 	 *      dictionaries, or arrays with the compound types having the same
@@ -167,7 +165,7 @@ class CardTransformer implements InputTransformer, OutputTransformer {
 	 * Called to get the column headers for a tabular output format eg csv.
 	 * The column count should match the number of fields in an array returned
 	 * by serialize() when $traverse is false
-	 * 
+	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
 	public function get_column_headers() : array {

--- a/src/Transform/ChargeTransformer.php
+++ b/src/Transform/ChargeTransformer.php
@@ -16,13 +16,11 @@ use Portalbox\Model\UserModel;
 /**
  * ChargeTransformer is our bridge between dictionary representations and
  * Charge entity instances.
- * 
- * @package Portalbox\Transform
  */
 class ChargeTransformer implements InputTransformer, OutputTransformer {
 	/**
 	 * Deserialize a Charge entity object from a dictionary
-	 * 
+	 *
 	 * @param array data - a dictionary representing a Charge
 	 * @return Charge - a valid entity object based on the data specified
 	 * @throws InvalidArgumentException if a require field is not specified
@@ -75,7 +73,7 @@ class ChargeTransformer implements InputTransformer, OutputTransformer {
 	/**
 	 * Called to serialize Charge entity instance to a dictionary
 	 *
-	 * @param bool $traverse - traverse the object graph if true, otherwise 
+	 * @param bool $traverse - traverse the object graph if true, otherwise
 	 *      may substitute flattened representations where appropriate.
 	 * @return array -  a dictionary whose values are null, string, int, float
 	 *      dictionaries, or arrays with the compound types having the same
@@ -118,7 +116,7 @@ class ChargeTransformer implements InputTransformer, OutputTransformer {
 	 * Called to get the column headers for a tabular output format eg csv.
 	 * The column count should match the number of fields in an array returned
 	 * by serialize() when $traverse is false
-	 * 
+	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
 	public function get_column_headers() : array {

--- a/src/Transform/ConfigOutputTransformer.php
+++ b/src/Transform/ConfigOutputTransformer.php
@@ -6,15 +6,13 @@ use DomainException;
 
 /**
  * ConfigTransformer is our bridge between the Config and the outputable portion
- * 
- * @package Portalbox\Transform
  */
 class ConfigOutputTransformer implements OutputTransformer {
 
 	/**
 	 * Called to serialize a Config
 	 *
-	 * @param bool $traverse - traverse the object graph if true, otherwise 
+	 * @param bool $traverse - traverse the object graph if true, otherwise
 	 *      may substitute flattened representations where appropriate.
 	 * @return array -  a dictionary whose values are null, string, int, float
 	 *      dictionaries, or arrays with the compound types having the same
@@ -29,7 +27,7 @@ class ConfigOutputTransformer implements OutputTransformer {
 	 * Called to get the column headers for a tabular output format eg csv.
 	 * The column count should match the number of fields in an array returned
 	 * by serialize() when $traverse is false
-	 * 
+	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
 	public function get_column_headers() : array {

--- a/src/Transform/EquipmentTransformer.php
+++ b/src/Transform/EquipmentTransformer.php
@@ -15,8 +15,6 @@ use Portalbox\Model\LocationModel;
 /**
  * EquipmentTransformer is our bridge between dictionary representations and
  * Equipment entity instances.
- *
- * @package Portalbox\Transform
  */
 class EquipmentTransformer implements InputTransformer, OutputTransformer {
 	/**

--- a/src/Transform/EquipmentTypeTransformer.php
+++ b/src/Transform/EquipmentTypeTransformer.php
@@ -10,13 +10,11 @@ use Portalbox\Entity\EquipmentType;
 /**
  * EquipmentTypeTransformer is our bridge between dictionary representations
  * and EquipmentType entity instances.
- * 
- * @package Portalbox\Transform
  */
 class EquipmentTypeTransformer implements InputTransformer, OutputTransformer {
 	/**
 	 * Deserialize an EquipmentType entity object from a dictionary
-	 * 
+	 *
 	 * @param array data - a dictionary representing a Role
 	 * @return EquipmentType - a valid entity object based on the data specified
 	 * @throws InvalidArgumentException if a require field is not specified
@@ -53,7 +51,7 @@ class EquipmentTypeTransformer implements InputTransformer, OutputTransformer {
 	/**
 	 * Called to serialize a Location entity instance to a dictionary
 	 *
-	 * @param bool $traverse - traverse the object graph if true, otherwise 
+	 * @param bool $traverse - traverse the object graph if true, otherwise
 	 *      may substitute flattened representations where appropriate.
 	 * @return array -  a dictionary whose values are null, string, int, float
 	 *      dictionaries, or arrays with the compound types having the same
@@ -87,7 +85,7 @@ class EquipmentTypeTransformer implements InputTransformer, OutputTransformer {
 	 * Called to get the column headers for a tabular output format eg csv.
 	 * The column count should match the number of fields in an array returned
 	 * by serialize() when $traverse is false
-	 * 
+	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
 	public function get_column_headers() : array {

--- a/src/Transform/InputTransformer.php
+++ b/src/Transform/InputTransformer.php
@@ -5,8 +5,6 @@ namespace Portalbox\Transform;
 /**
  * InputTransformers take a blob of data and reconstitute a valid Entity object
  * instance from the data
- * 
- * @package Portalbox\Transform
  */
 interface InputTransformer {
 

--- a/src/Transform/LocationTransformer.php
+++ b/src/Transform/LocationTransformer.php
@@ -9,13 +9,11 @@ use Portalbox\Entity\Location;
 /**
  * LocationTransformer is our bridge between dictionary representations and
  * Location entity instances.
- * 
- * @package Portalbox\Transform
  */
 class LocationTransformer implements InputTransformer, OutputTransformer {
 	/**
 	 * Deserialize a Location entity object from a dictionary
-	 * 
+	 *
 	 * @param array data - a dictionary representing a Location
 	 * @return Location - a valid entity object based on the data specified
 	 * @throws InvalidArgumentException if a require field is not specified
@@ -31,7 +29,7 @@ class LocationTransformer implements InputTransformer, OutputTransformer {
 	/**
 	 * Called to serialize a Location entity instance to a dictionary
 	 *
-	 * @param bool $traverse - traverse the object graph if true, otherwise 
+	 * @param bool $traverse - traverse the object graph if true, otherwise
 	 *      may substitute flattened representations where appropriate.
 	 * @return array -  a dictionary whose values are null, string, int, float
 	 *      dictionaries, or arrays with the compound types having the same
@@ -56,7 +54,7 @@ class LocationTransformer implements InputTransformer, OutputTransformer {
 	 * Called to get the column headers for a tabular output format eg csv.
 	 * The column count should match the number of fields in an array returned
 	 * by serialize() when $traverse is false
-	 * 
+	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
 	public function get_column_headers() : array {

--- a/src/Transform/LoggedEventTransformer.php
+++ b/src/Transform/LoggedEventTransformer.php
@@ -9,15 +9,13 @@ use Portalbox\Entity\LoggedEvent;
 /**
  * LoggedEventTransformer is our bridge between dictionary representations and
  * LoggedEvent entity instances.
- * 
- * @package Portalbox\Transform
  */
 class LoggedEventTransformer implements OutputTransformer {
 
 	/**
 	 * Called to serialize LoggedEvent entity instance to a dictionary
 	 *
-	 * @param bool $traverse - traverse the object graph if true, otherwise 
+	 * @param bool $traverse - traverse the object graph if true, otherwise
 	 *      may substitute flattened representations where appropriate.
 	 * @return array -  a dictionary whose values are null, string, int, float
 	 *      dictionaries, or arrays with the compound types having the same
@@ -54,7 +52,7 @@ class LoggedEventTransformer implements OutputTransformer {
 	 * Called to get the column headers for a tabular output format eg csv.
 	 * The column count should match the number of fields in an array returned
 	 * by serialize() when $traverse is false
-	 * 
+	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
 	public function get_column_headers() : array {

--- a/src/Transform/NullOutputTransformer.php
+++ b/src/Transform/NullOutputTransformer.php
@@ -7,15 +7,13 @@ use DomainException;
 /**
  * Implementors can Serialzable to a limited set of types which can be reliably
  * Transformed into a variety of output encodings
- * 
- * @package Portalbox\Transform
  */
 class NullOutputTransformer implements OutputTransformer {
 
 	/**
 	 * Called to serialize a non-entity
 	 *
-	 * @param bool $traverse - traverse the object graph if true, otherwise 
+	 * @param bool $traverse - traverse the object graph if true, otherwise
 	 *      may substitute flattened representations where appropriate.
 	 * @return array -  a dictionary whose values are null, string, int, float
 	 *      dictionaries, or arrays with the compound types having the same
@@ -24,14 +22,14 @@ class NullOutputTransformer implements OutputTransformer {
 	 */
 	public function serialize($data, bool $traverse = false) : array {
 		return $data;
-		
+
 	}
 
 	/**
 	 * Called to get the column headers for a tabular output format eg csv.
 	 * The column count should match the number of fields in an array returned
 	 * by serialize() when $traverse is false
-	 * 
+	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
 	public function get_column_headers() : array {

--- a/src/Transform/OutputTransformer.php
+++ b/src/Transform/OutputTransformer.php
@@ -5,14 +5,12 @@ namespace Portalbox\Transform;
 /**
  * Implementors can Serialzable to a limited set of types which can be reliably
  * Transformed into a variety of output encodings
- * 
- * @package Portalbox\Transform
  */
 interface OutputTransformer {
 
 	/**
 	 * Called to serialize an entity
-	 * 
+	 *
 	 * REST services end up with two output modes a single element and a list.
 	 * In the single element mode, the whole object graph is normally desired
 	 * while in the list mode a simplified graph is typically preferred. This
@@ -22,7 +20,7 @@ interface OutputTransformer {
 	 * typically the serialize entity is to be presented in a table or list
 	 * when $traverse is false.
 	 *
-	 * @param bool $traverse - traverse the object graph if true, otherwise 
+	 * @param bool $traverse - traverse the object graph if true, otherwise
 	 *      may substitute flattened representations where appropriate.
 	 * @return array -  a dictionary whose values are null, string, int, float
 	 *      dictionaries, or arrays with the compound types having the same
@@ -35,7 +33,7 @@ interface OutputTransformer {
 	 * Called to get the column headers for a tabular output format eg csv.
 	 * The column count should match the number of fields in an array returned
 	 * by serialize() when $traverse is false
-	 * 
+	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
 	public function get_column_headers() : array;

--- a/src/Transform/PaymentTransformer.php
+++ b/src/Transform/PaymentTransformer.php
@@ -14,13 +14,11 @@ use Portalbox\Model\UserModel;
 /**
  * PaymentTransformer is our bridge between dictionary representations and
  * Payment entity instances.
- * 
- * @package Portalbox\Transform
  */
 class PaymentTransformer implements InputTransformer, OutputTransformer {
 	/**
 	 * Deserialize a Payment entity object from a dictionary
-	 * 
+	 *
 	 * @param array data - a dictionary representing a Payment
 	 * @return Payment - a valid entity object based on the data specified
 	 * @throws InvalidArgumentException if a require field is not specified
@@ -50,7 +48,7 @@ class PaymentTransformer implements InputTransformer, OutputTransformer {
 	/**
 	 * Called to serialize a Payment entity instance to a dictionary
 	 *
-	 * @param bool $traverse - traverse the object graph if true, otherwise 
+	 * @param bool $traverse - traverse the object graph if true, otherwise
 	 *      may substitute flattened representations where appropriate.
 	 * @return array -  a dictionary whose values are null, string, int, float
 	 *      dictionaries, or arrays with the compound types having the same
@@ -79,7 +77,7 @@ class PaymentTransformer implements InputTransformer, OutputTransformer {
 	 * Called to get the column headers for a tabular output format eg csv.
 	 * The column count should match the number of fields in an array returned
 	 * by serialize() when $traverse is false
-	 * 
+	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
 	public function get_column_headers() : array {

--- a/src/Transform/RoleTransformer.php
+++ b/src/Transform/RoleTransformer.php
@@ -8,13 +8,11 @@ use Portalbox\Entity\Role;
 /**
  * RoleTransformer is our bridge between dictionary representations and Role
  * entity instances.
- * 
- * @package Portalbox\Transform
  */
 class RoleTransformer implements InputTransformer, OutputTransformer {
 	/**
 	 * Deserialize a Role entity object from a dictionary
-	 * 
+	 *
 	 * @param array data - a dictionary representing a Role
 	 * @return Role - a valid entity object based on the data specified
 	 * @throws InvalidArgumentException if a require field is not specified
@@ -40,7 +38,7 @@ class RoleTransformer implements InputTransformer, OutputTransformer {
 	/**
 	 * Called to serialize a Role entity instance to a dictionary
 	 *
-	 * @param bool $traverse - traverse the object graph if true, otherwise 
+	 * @param bool $traverse - traverse the object graph if true, otherwise
 	 *      may substitute flattened representations where appropriate.
 	 * @return array -  a dictionary whose values are null, string, int, float
 	 *      dictionaries, or arrays with the compound types having the same
@@ -70,7 +68,7 @@ class RoleTransformer implements InputTransformer, OutputTransformer {
 	 * Called to get the column headers for a tabular output format eg csv.
 	 * The column count should match the number of fields in an array returned
 	 * by serialize() when $traverse is false
-	 * 
+	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
 	public function get_column_headers() : array {

--- a/src/Transform/UserTransformer.php
+++ b/src/Transform/UserTransformer.php
@@ -15,13 +15,11 @@ use Portalbox\Model\RoleModel;
 /**
  * UserTransformer is our bridge between dictionary representations and User
  * entity instances.
- * 
- * @package Portalbox\Transform
  */
 class UserTransformer implements InputTransformer, OutputTransformer {
 	/**
 	 * Deserialize a Payment entity object from a dictionary
-	 * 
+	 *
 	 * @param array data - a dictionary representing a Payment
 	 * @return Payment - a valid entity object based on the data specified
 	 * @throws InvalidArgumentException if a require field is not specified
@@ -77,7 +75,7 @@ class UserTransformer implements InputTransformer, OutputTransformer {
 	/**
 	 * Called to serialize a User entity instance to a dictionary
 	 *
-	 * @param bool $traverse - traverse the object graph if true, otherwise 
+	 * @param bool $traverse - traverse the object graph if true, otherwise
 	 *      may substitute flattened representations where appropriate.
 	 * @return array -  a dictionary whose values are null, string, int, float
 	 *      dictionaries, or arrays with the compound types having the same
@@ -112,7 +110,7 @@ class UserTransformer implements InputTransformer, OutputTransformer {
 	 * Called to get the column headers for a tabular output format eg csv.
 	 * The column count should match the number of fields in an array returned
 	 * by serialize() when $traverse is false
-	 * 
+	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
 	public function get_column_headers() : array {


### PR DESCRIPTION
The `@package` annotation used to be recommended but is no longer as it is usually redundant with the namespace declaration