### PR TITLE
fix: serializer error preventing cards from listing when a user card exists

### DIFF
--- a/src/Entity/UserCard.php
+++ b/src/Entity/UserCard.php
@@ -10,17 +10,13 @@ class UserCard extends Card {
 
 	/**
 	 * The id of the user this card was issued to
-	 *
-	 * @var int
 	 */
-	private $user_id;
+	private int $user_id;
 
 	/**
 	 * The user this card was issued to
-	 *
-	 * @var User|null
 	 */
-	private $user = null;
+	private ?User $user = null;
 
 	/**
 	 * Get the type of the card

--- a/src/Transform/CardTransformer.php
+++ b/src/Transform/CardTransformer.php
@@ -123,7 +123,7 @@ class CardTransformer implements InputTransformer, OutputTransformer {
 					'card_type_id' => $card_type_id,
 					'card_type' => CardType::name_for_type($card_type_id),
 					'user_id' => $data->user_id(),
-					'user' => is_null($data->user) ? '' : $data->user->name(),
+					'user' => is_null($data->user()) ? '' : $data->user()->name(),
 					'equipment_type_id' => '',
 					'equipment_type' => ''
 				];


### PR DESCRIPTION
This PR if accepted corrects an issue that prevents the listing of user cards when running on PHP 8.4