### PR TITLE
documentation: scrub some missed references to previous SPA framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Maker Portal
 
 ## About
-This web application is the companion webite for a deployment of MakerSpace Portal Boxes. Consisting of two parts; a single page web application (SPA) built on the light weight moostaka+mustache framework with OAuth2 authentication using hellojs and a backend REST API built with PHP+PDO(mysql). By default, the website allows unauthenticated users to check the availability of equipment, authenticated users to check their account balances, and admins to administer the system. We have implemented a flexible role based access system allowing you to create new roles such as trainers or auditors.
+This web application is the companion webite for a deployment of MakerSpace Portal Boxes. Consisting of two parts; a single page web application (SPA) with OAuth2 authentication using hellojs and a backend REST API built with PHP+PDO(mysql). By default, the website allows unauthenticated users to check the availability of equipment, authenticated users to check their account balances, and admins to administer the system. We have implemented a flexible role based access system allowing you to create new roles such as trainers or auditors.
 
 ### Note on Conventions
 In some shell commands you may need to provide values left up to you. These values are denoted using the semi-standard shell variable syntax e.g. ${NAME_OF_DATA}

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -4,13 +4,11 @@ import { User } from './User.js';
 window.app = null;
 
 /**
- * While Moostaka is pretty great; simple, open source, has made this SPA
- * possible; there is a shortcoming: it's design really only supports
- * navigation by HTML link elements. Unfortunately, linking table rows is not
- * part of the HTML standard so we need a bit of a work around. We will bind
- * the click event of table rows to this helper function making them work with
- * moostaka as if they are links.
- * 
+ * Our SPA router really only supports navigation by HTML link elements.
+ * Unfortunately, linking table rows is not part of the HTML standard so we need
+ * a bit of a work around. We will bind the click event of table rows to this
+ * helper function making them work as if they are links.
+ *
  * go - make the browser "navigate" to the given url even when when the url is
  *     virtual, ie only valid in the SPA
  * @param (string)destination_url - the location to which the browser should


### PR DESCRIPTION
This PR if accepted scrubs a few leftover references to the abandoned SPA framework we had previously used from documentation.