### PR TITLE
chore: adopt PSR-12 no space between ) and : for return type rule

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -42,7 +42,7 @@ class Config {
 	 *
 	 * @return Config - the singleton configuration
 	 */
-	public static function config() : Config {
+	public static function config(): Config {
 		if(!self::$instance) {
 			self::$instance = new Config();
 		}
@@ -57,7 +57,7 @@ class Config {
 	 *		contain the necessary configuration parameters
 	 * @return PDO - a connection to the database
 	 */
-	private function connection() : PDO {
+	private function connection(): PDO {
 		$connection = null;
 
 		if(FALSE != $this->settings && array_key_exists('database', $this->settings)) {
@@ -84,7 +84,7 @@ class Config {
 	 *		contain the necessary configuration parameters
 	 * @return PDO - a connection to the database
 	 */
-	public function writable_db_connection() : PDO {
+	public function writable_db_connection(): PDO {
 		return $this->connection();
 	}
 
@@ -102,7 +102,7 @@ class Config {
 	 *		contain the necessary configuration parameters
 	 * @return PDO - a connection to the database
 	 */
-	public function readonly_db_connection() : PDO {
+	public function readonly_db_connection(): PDO {
 		return $this->connection();
 	}
 
@@ -110,7 +110,7 @@ class Config {
 	 * Get the settings for the web ui
 	 *
 	 */
-	public function web_ui_settings() : array {
+	public function web_ui_settings(): array {
 		if(FALSE != $this->settings && array_key_exists('oauth', $this->settings)) {
 			return $this->settings['oauth'];
 		}

--- a/src/Entity/APIKey.php
+++ b/src/Entity/APIKey.php
@@ -23,7 +23,7 @@ class APIKey {
 	/**
 	 * Get the name of this API key
 	 */
-	public function name() : string {
+	public function name(): string {
 		return $this->name;
 	}
 
@@ -32,7 +32,7 @@ class APIKey {
 	 *
 	 * @throws InvalidArgumentException if the name is the empty string
 	 */
-	public function set_name(string $name) : self {
+	public function set_name(string $name): self {
 		if($name === '') {
 			throw new InvalidArgumentException('You must specify the API key\'s name');
 		}
@@ -45,7 +45,7 @@ class APIKey {
 	 * Get token that can be presented to authenticate to the API in the
 	 * absence of a Session
 	 */
-	public function token() : string {
+	public function token(): string {
 		if(NULL === $this->token) {
 			$this->token = $this->create_token();
 		}
@@ -56,7 +56,7 @@ class APIKey {
 	 * Set token that can be presented to authenticate to the API in the
 	 * absence of a Session
 	 */
-	public function set_token(string $token) : self {
+	public function set_token(string $token): self {
 		$this->token = $token;
 		return $this;
 	}

--- a/src/Entity/Card.php
+++ b/src/Entity/Card.php
@@ -14,5 +14,4 @@ abstract class Card {
 	 * by CardType
 	 */
 	abstract public function type_id(): int;
-
 }

--- a/src/Entity/CardType.php
+++ b/src/Entity/CardType.php
@@ -33,12 +33,12 @@ class CardType {
 	protected string $name = 'Invalid';
 
 	/** Get the card type's human readable name */
-	public function name() : string {
+	public function name(): string {
 		return $this->name;
 	}
 
 	/** Set the card type's human readable name */
-	private function set_name(string $name) : self {
+	private function set_name(string $name): self {
 		if(0 < strlen($name)) {
 			$this->name = $name;
 			return $this;
@@ -46,12 +46,12 @@ class CardType {
 	}
 
 	/** Get the card type's id */
-	public function id() : int {
+	public function id(): int {
 		return $this->id;
 	}
 
 	/** Set the card type's id */
-	public function set_id(int $id) : self {
+	public function set_id(int $id): self {
 		$this->id = $id;
 		$this->set_name(CardType::name_for_type($id));
 		return $this;
@@ -78,13 +78,18 @@ class CardType {
 	 * @param int type_id  the id of the card type
 	 * @return string  the name for the card type
 	 */
-	public static function name_for_type(int $type_id) : string {
+	public static function name_for_type(int $type_id): string {
 		switch($type_id) {
-			case self::SHUTDOWN: return 'Shutdown Card';
-			case self::PROXY: return 'Proxy Card';
-			case self::TRAINING: return 'Training Card';
-			case self::USER: return 'User Card';
-			default: return 'Invalid';
+			case self::SHUTDOWN:
+				return 'Shutdown Card';
+			case self::PROXY:
+				return 'Proxy Card';
+			case self::TRAINING:
+				return 'Training Card';
+			case self::USER:
+				return 'User Card';
+			default:
+				return 'Invalid';
 		}
 	}
 }

--- a/src/Entity/Charge.php
+++ b/src/Entity/Charge.php
@@ -42,18 +42,18 @@ class Charge {
 	protected int $charged_time = 0;
 
 	/** Get the id of the user who paid */
-	public function user_id() : int {
+	public function user_id(): int {
 		return $this->user_id;
 	}
 
 	/** Set the id of the user who paid */
-	public function set_user_id(int $user_id) : self {
+	public function set_user_id(int $user_id): self {
 		$this->user_id = $user_id;
 		return $this;
 	}
 
 	/** Get the charged user's name */
-	public function user_name() : string {
+	public function user_name(): string {
 		$user = $this->user();
 		if ($user === NULL) {
 			return '';
@@ -63,30 +63,30 @@ class Charge {
 	}
 
 	/** Get the charged user */
-	public function user() : ?User {
+	public function user(): ?User {
 		return $this->user;
 	}
 
 	/** Set the charged user */
-	public function set_user(User $user) : self {
+	public function set_user(User $user): self {
 		$this->user = $user;
 		$this->user_id = $user->id();
 		return $this;
 	}
 
 	/** Get the id of the equipment the user used to incur the Charge */
-	public function equipment_id() : int {
+	public function equipment_id(): int {
 		return $this->equipment_id;
 	}
 
 	/** Set the id of the equipment the user used to incur the Charge */
-	public function set_equipment_id(int $equipment_id) : self {
+	public function set_equipment_id(int $equipment_id): self {
 		$this->equipment_id = $equipment_id;
 		return $this;
 	}
 
 	/** Get the name of the equipment the user used to incur the Charge */
-	public function equipment_name() : string {
+	public function equipment_name(): string {
 		$equipment = $this->equipment();
 		if ($equipment === NULL) {
 			return '';
@@ -96,41 +96,41 @@ class Charge {
 	}
 
 	/** Get the equipment the user used to incur the Charge */
-	public function equipment() : ?Equipment {
+	public function equipment(): ?Equipment {
 		return $this->equipment;
 	}
 
 	/** Set the equipment the user used to incur the Charge */
-	public function set_equipment(Equipment $equipment) : self {
+	public function set_equipment(Equipment $equipment): self {
 		$this->equipment = $equipment;
 		$this->equipment_id = $equipment->id();
 		return $this;
 	}
 
 	/** Get the time of this charge */
-	public function time() : string {
+	public function time(): string {
 		return $this->time;
 	}
 
 	/** Set the time of this charge */
-	public function set_time(string $time) : self {
+	public function set_time(string $time): self {
 		$this->time = $time;
 		return $this;
 	}
 
 	/** Get the amount of this charge */
-	public function amount() : string {
+	public function amount(): string {
 		return $this->amount;
 	}
 
 	/** Set the amount of this charge */
-	public function set_amount(string $amount) : self {
+	public function set_amount(string $amount): self {
 		$this->amount = $amount;
 		return $this;
 	}
 
 	/** Get the policy for this charge */
-	public function charge_policy() : string {
+	public function charge_policy(): string {
 		return ChargePolicy::name_for_policy($this->charge_policy_id);
 	}
 
@@ -138,7 +138,7 @@ class Charge {
 	 * Get the id of the charge policy in effect during the creation of the
 	 * Charge
 	 */
-	public function charge_policy_id() : int {
+	public function charge_policy_id(): int {
 		return $this->charge_policy_id;
 	}
 
@@ -146,18 +146,18 @@ class Charge {
 	 * Set the id of the charge policy in effect during the creation of the
 	 * Charge
 	 */
-	public function set_charge_policy_id(int $charge_policy_id) : self {
+	public function set_charge_policy_id(int $charge_policy_id): self {
 		$this->charge_policy_id = $charge_policy_id;
 		return $this;
 	}
 
 	/** Get the charge rate in effect during the creation of the Charge */
-	public function charge_rate() : string {
+	public function charge_rate(): string {
 		return $this->charge_rate;
 	}
 
 	/** Set the charge rate in effect during the creation of the Charge */
-	public function set_charge_rate(string $charge_rate) : self {
+	public function set_charge_rate(string $charge_rate): self {
 		$this->charge_rate = $charge_rate;
 		return $this;
 	}
@@ -166,7 +166,7 @@ class Charge {
 	 * Get duration in seconds of the activation session that resulted in the
 	 * creation of this Charge
 	 */
-	public function charged_time() : int {
+	public function charged_time(): int {
 		return $this->charged_time;
 	}
 
@@ -174,7 +174,7 @@ class Charge {
 	 * Set duration in seconds of the activation session that resulted in the
 	 * creation of this Charge
 	 */
-	public function set_charged_time(int $charged_time) : self {
+	public function set_charged_time(int $charged_time): self {
 		$this->charged_time = $charged_time;
 		return $this;
 	}

--- a/src/Entity/ChargePolicy.php
+++ b/src/Entity/ChargePolicy.php
@@ -59,7 +59,7 @@ class ChargePolicy {
 	 * @param int policy_id - the policy id to check
 	 * @return string - name for the charge policy
 	 */
-	public static function name_for_policy(int $policy_id) : string {
+	public static function name_for_policy(int $policy_id): string {
 		switch($policy_id) {
 			case self::MANUALLY_ADJUSTED: return 'Manually Adjusted';
 			case self::NO_CHARGE: return 'No Charge';

--- a/src/Entity/Equipment.php
+++ b/src/Entity/Equipment.php
@@ -47,7 +47,7 @@ class Equipment {
 	protected ?string $ip_address = NULL;
 
 	/** Get the name of this equipment */
-	public function name() : string {
+	public function name(): string {
 		return $this->name;
 	}
 
@@ -56,7 +56,7 @@ class Equipment {
 	 *
 	 * @throws InvalidArgumentException  if the parameter is the empty string
 	 */
-	public function set_name(string $name) : self {
+	public function set_name(string $name): self {
 		if($name === '') {
 			throw new InvalidArgumentException('You must specify the equipment\'s name');
 		}
@@ -66,31 +66,31 @@ class Equipment {
 	}
 
 	/** Get the equipment's type id */
-	public function type_id() : int {
+	public function type_id(): int {
 		return $this->type_id;
 	}
 
 	/** Set the equipment's type id */
-	public function set_type_id(int $type_id) : self {
+	public function set_type_id(int $type_id): self {
 		$this->type_id = $type_id;
 		$this->type = NULL;
 		return $this;
 	}
 
 	/** Get the equipment's type */
-	public function type() : ?EquipmentType {
+	public function type(): ?EquipmentType {
 		return $this->type;
 	}
 
 	/** Set the equipment's type */
-	public function set_type(EquipmentType $type) : self {
+	public function set_type(EquipmentType $type): self {
 		$this->type = $type;
 		$this->type_id = $type->id();
 		return $this;
 	}
 
 	/** Get the MAC address of the portalbox this equipment is connected to */
-	public function mac_address() : ?string {
+	public function mac_address(): ?string {
 		return $this->mac_address;
 	}
 
@@ -100,7 +100,7 @@ class Equipment {
 	 * @throws InvalidArgumentException  if the parameter is not a valid MAC
 	 *     address.
 	 */
-	public function set_mac_address(?string $mac_address) : self {
+	public function set_mac_address(?string $mac_address): self {
 		if(is_null($mac_address)) {
 			$this->mac_address = NULL;
 			return $this;
@@ -115,80 +115,80 @@ class Equipment {
 	}
 
 	/** Get the equipment's location id */
-	public function location_id() : int {
+	public function location_id(): int {
 		return $this->location_id;
 	}
 
 	/** Set the equipment's location id */
-	public function set_location_id(int $location_id) : self {
+	public function set_location_id(int $location_id): self {
 		$this->location_id = $location_id;
 		$this->location = NULL;
 		return $this;
 	}
 
 	/** Get the equipment's location */
-	public function location() : ?Location {
+	public function location(): ?Location {
 		return $this->location;
 	}
 
 	/** Set the equipment's location */
-	public function set_location(Location $location) : self {
+	public function set_location(Location $location): self {
 		$this->location = $location;
 		$this->location_id = $location->id();
 		return $this;
 	}
 
 	/** Get the equipment's timeout */
-	public function timeout() : int {
+	public function timeout(): int {
 		return $this->timeout;
 	}
 
 	/** Set the equipment's timeout */
-	public function set_timeout(int $timeout) : self {
+	public function set_timeout(int $timeout): self {
 		$this->timeout = $timeout;
 		return $this;
 	}
 
 	/** Get whether the equipment is in service */
-	public function is_in_service() : bool {
+	public function is_in_service(): bool {
 		return $this->is_in_service;
 	}
 
 	/** Set whether the equipment is in service */
-	public function set_is_in_service(bool $is_in_service) : self {
+	public function set_is_in_service(bool $is_in_service): self {
 		$this->is_in_service = $is_in_service;
 		return $this;
 	}
 
 	/** Get whether the equipment is in use */
-	public function is_in_use() : bool {
+	public function is_in_use(): bool {
 		return $this->is_in_use;
 	}
 
 	/** Set whether the equipment is in use */
-	public function set_is_in_use(bool $is_in_use) : self {
+	public function set_is_in_use(bool $is_in_use): self {
 		$this->is_in_use = $is_in_use;
 		return $this;
 	}
 
 	/** Get the equipment's service minutes */
-	public function service_minutes() : int {
+	public function service_minutes(): int {
 		return $this->service_minutes;
 	}
 
 	/** Set the equipment's service minutes */
-	public function set_service_minutes(int $service_minutes) : self {
+	public function set_service_minutes(int $service_minutes): self {
 		$this->service_minutes = $service_minutes;
 		return $this;
 	}
 
 	/** Get the ip address */
-	public function ip_address() : ?string {
+	public function ip_address(): ?string {
 		return $this->ip_address;
 	}
 
 	/** Set the ip address */
-	public function set_ip_address(?string $ip_address) : self {
+	public function set_ip_address(?string $ip_address): self {
 		$this->ip_address = $ip_address;
 		return $this;
 	}

--- a/src/Entity/EquipmentType.php
+++ b/src/Entity/EquipmentType.php
@@ -26,12 +26,12 @@ class EquipmentType {
 	protected bool $allow_proxy = false;
 
 	/** Get the name of this equipment type */
-	public function name() : string {
+	public function name(): string {
 		return $this->name;
 	}
 
 	/** Set the name of this equipment type */
-	public function set_name(string $name) : self {
+	public function set_name(string $name): self {
 		if($name === '') {
 			throw new InvalidArgumentException('You must specify the equipment type\'s name');
 		}
@@ -41,23 +41,23 @@ class EquipmentType {
 	}
 
 	/** Get whether this equipment type requires training */
-	public function requires_training() : bool {
+	public function requires_training(): bool {
 		return $this->requires_training;
 	}
 
 	/** Set whether this equipment type requires training */
-	public function set_requires_training(bool $requires_training) : self {
+	public function set_requires_training(bool $requires_training): self {
 		$this->requires_training = $requires_training;
 		return $this;
 	}
 
 	/** Get the charge rate this equipment type */
-	public function charge_rate() : ?string {
+	public function charge_rate(): ?string {
 		return $this->charge_rate;
 	}
 
 	/** Set the charge rate of this equipment type */
-	public function set_charge_rate(?string $charge_rate) : self {
+	public function set_charge_rate(?string $charge_rate): self {
 		if(NULL === $charge_rate || $charge_rate !== '') {
 			$this->charge_rate = $charge_rate;
 			return $this;
@@ -70,12 +70,12 @@ class EquipmentType {
 	 * Get the charge policy id for this equipment type. Must be one of the
 	 * public ChargePolicy constants
 	 */
-	public function charge_policy_id() : int {
+	public function charge_policy_id(): int {
 		return $this->charge_policy_id;
 	}
 
 	/** Get the charge policy for this equipment type */
-	public function charge_policy() : string {
+	public function charge_policy(): string {
 		return ChargePolicy::name_for_policy($this->charge_policy_id);
 	}
 
@@ -84,7 +84,7 @@ class EquipmentType {
 	 * @throws InvalidArgumentException if the specified id is not one of the
 	 *             public constants from ChargePolicy
 	 */
-	public function set_charge_policy_id(int $charge_policy_id) : self {
+	public function set_charge_policy_id(int $charge_policy_id): self {
 		if(ChargePolicy::is_valid($charge_policy_id)) {
 			$this->charge_policy_id = $charge_policy_id;
 			return $this;
@@ -94,12 +94,12 @@ class EquipmentType {
 	}
 
 	/** Get whether this equipment type allows proxy cards */
-	public function allow_proxy() : bool {
+	public function allow_proxy(): bool {
 		return $this->allow_proxy;
 	}
 
 	/** Set whether this equipment type allows proxy cards */
-	public function set_allow_proxy(bool $allow_proxy) : self {
+	public function set_allow_proxy(bool $allow_proxy): self {
 		$this->allow_proxy = $allow_proxy;
 		return $this;
 	}

--- a/src/Entity/Location.php
+++ b/src/Entity/Location.php
@@ -18,7 +18,7 @@ class Location {
 	protected string $name = '';
 
 	/** Get the name of this location */
-	public function name() : string {
+	public function name(): string {
 		return $this->name;
 	}
 
@@ -27,7 +27,7 @@ class Location {
 	 *
 	 * @throws InvalidArgumentException if the name is the empty string
 	 */
-	public function set_name(string $name) : self {
+	public function set_name(string $name): self {
 		if($name === '') {
 			throw new InvalidArgumentException('You must specify the location\'s name');
 		}

--- a/src/Entity/LoggedEvent.php
+++ b/src/Entity/LoggedEvent.php
@@ -40,39 +40,39 @@ class LoggedEvent {
 
 
 	/** Get the time this event occurred */
-	public function time() : string {
+	public function time(): string {
 		return $this->time;
 	}
 
 	/** Set the time this event occurred */
-	public function set_time(string $time) : self {
+	public function set_time(string $time): self {
 		$this->time = $time;
 		return $this;
 	}
 
 	/** Get the type of this event */
-	public function type_id() : int {
+	public function type_id(): int {
 		return $this->type_id;
 	}
 
 	/** Set the type_id of this event */
-	public function set_type_id(int $type_id) : self {
+	public function set_type_id(int $type_id): self {
 		$this->type_id = $type_id;
 		return $this;
 	}
 
 	/** Get the event type for this event */
-	public function type() : string {
+	public function type(): string {
 		return LoggedEventType::name_for_type($this->type_id);
 	}
 
 	/** Get the id of the equipment which reported this event */
-	public function equipment_id() : int {
+	public function equipment_id(): int {
 		return $this->equipment_id;
 	}
 
 	/** Set the id of the equipment which reported this event */
-	public function set_equipment_id(int $equipment_id) : self {
+	public function set_equipment_id(int $equipment_id): self {
 		$this->equipment_id = $equipment_id;
 		$this->equipment = NULL;
 		return $this;
@@ -80,7 +80,7 @@ class LoggedEvent {
 
 	// a convenience method... see Model\Entity\LoggedEventModel ;)
 	/** Get the name of the equipment which reported this event */
-	public function equipment_name() : ?string {
+	public function equipment_name(): ?string {
 		if(NULL === $this->equipment) {
 			return '';
 		}
@@ -89,12 +89,12 @@ class LoggedEvent {
 	}
 
 	/** Get the equipment which reported this event */
-	public function equipment() : ?Equipment {
+	public function equipment(): ?Equipment {
 		return $this->equipment;
 	}
 
 	/** Set the equipment which reported this event */
-	public function set_equipment(?Equipment $equipment) : self {
+	public function set_equipment(?Equipment $equipment): self {
 		$this->equipment = $equipment;
 		if(NULL === $equipment) {
 			$this->equipment_id = -1;
@@ -106,24 +106,24 @@ class LoggedEvent {
 	}
 
 	/** Get the id of the card which triggered this event */
-	public function card_id() : ?int {
+	public function card_id(): ?int {
 		return $this->card_id;
 	}
 
 	/** Set the id of the card which triggered this event */
-	public function set_card_id(int $card_id) : self {
+	public function set_card_id(int $card_id): self {
 		$this->card_id = $card_id;
 		$this->card = NULL;
 		return $this;
 	}
 
 	/** Get the card which triggered this event */
-	public function card() : ?Card {
+	public function card(): ?Card {
 		return $this->card;
 	}
 
 	/** Set the card which triggered this event */
-	public function set_card(?Card $card) : self {
+	public function set_card(?Card $card): self {
 		$this->card = $card;
 		if(NULL === $card) {
 			$this->card_id = -1;
@@ -135,12 +135,12 @@ class LoggedEvent {
 	}
 
 	/** Get the id of the user whose card which triggered this event */
-	public function user_id() : int {
+	public function user_id(): int {
 		return $this->user_id;
 	}
 
 	/** Set the id of the user whose card which triggered this event */
-	public function set_user_id(int $user_id) : self {
+	public function set_user_id(int $user_id): self {
 		$this->user_id = $user_id;
 		$this->user = NULL;
 		return $this;
@@ -148,7 +148,7 @@ class LoggedEvent {
 
 	// a convenience method... see Model\Entity\LoggedEventModel ;)
 	/** Get the name of the user whose action triggered this event */
-	public function user_name() : string {
+	public function user_name(): string {
 		if(NULL === $this->user) {
 			return '';
 		}
@@ -157,12 +157,12 @@ class LoggedEvent {
 	}
 
 	/** Get the user whose card which triggered this event */
-	public function user() : ?User {
+	public function user(): ?User {
 		return $this->user;
 	}
 
 	/** Set the user whose card which triggered this event */
-	public function set_user(?User $user) : self {
+	public function set_user(?User $user): self {
 		$this->user = $user;
 		if(NULL === $user) {
 			$this->user_id = -1;
@@ -178,7 +178,7 @@ class LoggedEvent {
 	 * Get the name of the location where the equipment which triggered this
 	 * event is located
 	 */
-	public function location_name() : ?string {
+	public function location_name(): ?string {
 		if(NULL === $this->equipment) {
 			return '';
 		}
@@ -186,20 +186,20 @@ class LoggedEvent {
 		return $this->equipment->location()->name();
 	}
 
-	public function equipment_type_id() : ?int {
+	public function equipment_type_id(): ?int {
 		return $this->equipment_type_id;
 	}
 
-	public function set_equipment_type_id(int $equipment_type_id) : self {
+	public function set_equipment_type_id(int $equipment_type_id): self {
 		$this->equipment_type_id = $equipment_type_id;
 		return $this;
 	}
 
-	public function equipment_type() : ?string {
+	public function equipment_type(): ?string {
 		return $this->equipment_type;
 	}
 
-	public function set_equipment_type(string $equipment_type) : self {
+	public function set_equipment_type(string $equipment_type): self {
 		$this->equipment_type = $equipment_type;
 		return $this;
 	}

--- a/src/Entity/LoggedEventType.php
+++ b/src/Entity/LoggedEventType.php
@@ -64,7 +64,7 @@ class LoggedEventType {
 	 * @param int type_id - the policy id to check
 	 * @return string - name for the event type
 	 */
-	public static function name_for_type(int $type_id) : string {
+	public static function name_for_type(int $type_id): string {
 		switch($type_id) {
 			case self::UNSUCCESSFUL_AUTHENTICATION: return 'Failed Authentication';
 			case self::SUCCESSFUL_AUTHENTICATION: return 'Activation Session Begun';

--- a/src/Entity/Payment.php
+++ b/src/Entity/Payment.php
@@ -22,46 +22,46 @@ class Payment {
 	private ?User $user = null;
 
 	/** Get the id of the user who paid */
-	public function user_id() : int {
+	public function user_id(): int {
 		return $this->user_id;
 	}
 
 	/** Set the id of the user who paid */
-	public function set_user_id(int $user_id) : self {
+	public function set_user_id(int $user_id): self {
 		$this->user_id = $user_id;
 		return $this;
 	}
 
 	/** Get the user who paid */
-	public function user() : ?User {
+	public function user(): ?User {
 		return $this->user;
 	}
 
 	/** Set the user who paid */
-	public function set_user(User $user) : self {
+	public function set_user(User $user): self {
 		$this->user = $user;
 		$this->user_id = $user->id();
 		return $this;
 	}
 
 	/** Get the amount of this payment */
-	public function amount() : string {
+	public function amount(): string {
 		return $this->amount;
 	}
 
 	/** Set the amount of this payment */
-	public function set_amount(string $amount) : self {
+	public function set_amount(string $amount): self {
 		$this->amount = $amount;
 		return $this;
 	}
 
 	/** Get the time of this payment */
-	public function time() : string {
+	public function time(): string {
 		return $this->time;
 	}
 
 	/** Set the time of this payment */
-	public function set_time(string $time) : self {
+	public function set_time(string $time): self {
 		$this->time = $time;
 		return $this;
 	}

--- a/src/Entity/ProxyCard.php
+++ b/src/Entity/ProxyCard.php
@@ -12,7 +12,7 @@ namespace Portalbox\Entity;
  */
 class ProxyCard extends Card {
 	/** Get the type of the card */
-	public function type_id() : int {
+	public function type_id(): int {
 		return CardType::PROXY;
 	}
 }

--- a/src/Entity/Role.php
+++ b/src/Entity/Role.php
@@ -30,34 +30,34 @@ class Role {
 	protected ?array $permissions = NULL;
 
 	/** Get the name of this role */
-	public function name() : string {
+	public function name(): string {
 		return $this->name;
 	}
 
 	/** Set the name of this role */
-	public function set_name(string $name) : self {
+	public function set_name(string $name): self {
 		$this->name = $name;
 		return $this;
 	}
 
 	/** Get whether this role is a system role */
-	public function is_system_role() : bool {
+	public function is_system_role(): bool {
 		return $this->is_system_role;
 	}
 
 	/** Set whether this role is a system role */
-	public function set_is_system_role(bool $is_system_role) : self {
+	public function set_is_system_role(bool $is_system_role): self {
 		$this->is_system_role = $is_system_role;
 		return $this;
 	}
 
 	/** Get the description of this role */
-	public function description() : string {
+	public function description(): string {
 		return $this->description;
 	}
 
 	/** Set the description of this role */
-	public function set_description(string $description) : self {
+	public function set_description(string $description): self {
 		$this->description = $description;
 		return $this;
 	}
@@ -67,7 +67,7 @@ class Role {
 	 *
 	 * @return int[]  the list of the role's permissions
 	 */
-	public function permissions() : array {
+	public function permissions(): array {
 		if(NULL === $this->permissions) {
 			return array();
 		}
@@ -81,7 +81,7 @@ class Role {
 	 * @throws InvalidArgumentException if any of the  specified permission are
 	 *             not not one of the public constants from Permission
 	 */
-	public function set_permissions(array $permissions) : self {
+	public function set_permissions(array $permissions): self {
 		foreach($permissions as $permission) {
 			if(!Permission::is_valid($permission)) {
 				throw new InvalidArgumentException('permission must be one of the public constants from Permission');
@@ -93,7 +93,7 @@ class Role {
 	}
 
 	/** Determine whether the role has a permission */
-	public function has_permission(int $permission) : bool {
+	public function has_permission(int $permission): bool {
 		if(is_array($this->permissions)) {
 			return in_array($permission, $this->permissions);
 		} else {

--- a/src/Entity/ShutdownCard.php
+++ b/src/Entity/ShutdownCard.php
@@ -8,7 +8,7 @@ namespace Portalbox\Entity;
  */
 class ShutdownCard extends Card {
 	/** Get the type of the card */
-	public function type_id() : int {
+	public function type_id(): int {
 		return CardType::SHUTDOWN;
 	}
 }

--- a/src/Entity/TrainingCard.php
+++ b/src/Entity/TrainingCard.php
@@ -27,7 +27,7 @@ class TrainingCard extends Card {
 	 *
 	 * @return int - type one of the predefined constants exposed by CardType
 	 */
-	public function type_id() : int {
+	public function type_id(): int {
 		return CardType::TRAINING;
 	}
 
@@ -37,7 +37,7 @@ class TrainingCard extends Card {
 	 * @return int - the id of the type of equipment this card can activate for
 	 *               training
 	 */
-	public function equipment_type_id() : int {
+	public function equipment_type_id(): int {
 		return $this->equipment_type_id;
 	}
 
@@ -48,7 +48,7 @@ class TrainingCard extends Card {
 	 *               can activate for training
 	 * @return self
 	 */
-	public function set_equipment_type_id(int $equipment_type_id) : self {
+	public function set_equipment_type_id(int $equipment_type_id): self {
 		$this->equipment_type_id = $equipment_type_id;
 		$this->equipment_type = NULL;
 		return $this;
@@ -60,11 +60,11 @@ class TrainingCard extends Card {
 	 * @return EquipmentType|null - the type of equipment this card can
 	 *               activate for training
 	 */
-	public function equipment_type() : ?EquipmentType {
+	public function equipment_type(): ?EquipmentType {
 		return $this->equipment_type;
 	}
 
-	public function set_equipment_type(?EquipmentType $equipment_type) : self{
+	public function set_equipment_type(?EquipmentType $equipment_type): self{
 		$this->equipment_type = $equipment_type;
 		return $this;
 	}
@@ -76,7 +76,7 @@ class TrainingCard extends Card {
 	 *               card can activate for training
 	 * @return self
 	 */
-	public function set_type(?EquipmentType $equipment_type) : self {
+	public function set_type(?EquipmentType $equipment_type): self {
 		$this->equipment_type = $equipment_type;
 		if(NULL === $equipment_type) {
 			$this->equipment_type_id = -1;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -38,52 +38,52 @@ class User {
 	protected ?array $authorizations = null;
 
 	/** Get the name of this user */
-	public function name() : string {
+	public function name(): string {
 		return $this->name;
 	}
 
 	/** Set the name of this user */
-	public function set_name(string $name) : self {
+	public function set_name(string $name): self {
 		$this->name = $name;
 		return $this;
 	}
 
 	/** Get the email address of this user */
-	public function email() : string {
+	public function email(): string {
 		return $this->email;
 	}
 
 	/** Set the email address of this user */
-	public function set_email(string $email) : self {
+	public function set_email(string $email): self {
 		$this->email = $email;
 		return $this;
 	}
 
 	/** Get the comment for this user */
-	public function comment() : ?string {
+	public function comment(): ?string {
 		return $this->comment;
 	}
 
 	/** Set the comment for this user */
-	public function set_comment(?string $comment) : self {
+	public function set_comment(?string $comment): self {
 		$this->comment = $comment;
 		return $this;
 	}
 
 	/** Get this user's role id */
-	public function role_id() : int {
+	public function role_id(): int {
 		return $this->role_id;
 	}
 
 	/** Set the user's role id */
-	public function set_role_id(int $role_id) : self {
+	public function set_role_id(int $role_id): self {
 		$this->role_id = $role_id;
 		$this->role = NULL;
 		return $this;
 	}
 
 	/** Get the user's role's name */
-	public function role_name() : string {
+	public function role_name(): string {
 		if(NULL === $this->role) {
 			return '';
 		} else {
@@ -92,12 +92,12 @@ class User {
 	}
 
 	/** Get this user's role */
-	public function role() : ?Role {
+	public function role(): ?Role {
 		return $this->role;
 	}
 
 	/** Set the user's role */
-	public function set_role(?Role $role) : self {
+	public function set_role(?Role $role): self {
 		$this->role = $role;
 		if(NULL === $role) {
 			$this->role_id = -1;
@@ -109,18 +109,18 @@ class User {
 	}
 
 	/** Get whether this user is active */
-	public function is_active() : bool {
+	public function is_active(): bool {
 		return $this->is_active;
 	}
 
 	/** Set whether this user is active */
-	public function set_is_active(bool $is_active) : self {
+	public function set_is_active(bool $is_active): self {
 		$this->is_active = $is_active;
 		return $this;
 	}
 
 	/** Get the authorizations for this user */
-	public function authorizations() : array {
+	public function authorizations(): array {
 		if(NULL === $this->authorizations) {
 			return array();
 		}
@@ -132,7 +132,7 @@ class User {
 	 *
 	 * @param int[] $authorizations  the authorizations for this user
 	 */
-	public function set_authorizations(array $authorizations) : self {
+	public function set_authorizations(array $authorizations): self {
 		// Should check if valid? ie an int that is the id of an equipment type
 
 		$this->authorizations = $authorizations;

--- a/src/Entity/UserCard.php
+++ b/src/Entity/UserCard.php
@@ -22,7 +22,7 @@ class UserCard extends Card {
 	 *
 	 * @return int - type one of the predefined constants exposed by CardType
 	 */
-	public function type_id() : int {
+	public function type_id(): int {
 		return CardType::USER;
 	}
 
@@ -31,7 +31,7 @@ class UserCard extends Card {
 	 *
 	 * @return int - the id of the user to whom this card was issued
 	 */
-	public function user_id() : ?int {
+	public function user_id(): ?int {
 		return $this->user_id;
 	}
 
@@ -41,7 +41,7 @@ class UserCard extends Card {
 	 * @param int user_id - the id of the user to whom this card was issued
 	 * @return self
 	 */
-	public function set_user_id(?int $user_id) : self {
+	public function set_user_id(?int $user_id): self {
 		$this->user_id = $user_id;
 		$this->user = NULL; //Create new user from user_id
 		return $this;
@@ -52,7 +52,7 @@ class UserCard extends Card {
 	 *
 	 * @return User|null - user to whom this card was issued
 	 */
-	public function user() : ?User {
+	public function user(): ?User {
 		return $this->user;
 	}
 
@@ -62,7 +62,7 @@ class UserCard extends Card {
 	 * @param User|null user - user to whom this card was issued
 	 * @return self
 	 */
-	public function set_user(?User $user) : self {
+	public function set_user(?User $user): self {
 		$this->user = $user;
 		if(NULL === $user) {
 			$this->user_id = -1;

--- a/src/Exception/DatabaseException.php
+++ b/src/Exception/DatabaseException.php
@@ -5,5 +5,4 @@ namespace Portalbox\Exception;
 use Exception;
 
 class DatabaseException extends Exception {
-
 }

--- a/src/Exception/InvalidConfigurationException.php
+++ b/src/Exception/InvalidConfigurationException.php
@@ -5,5 +5,4 @@ namespace Portalbox\Exception;
 use Exception;
 
 class InvalidConfigurationException extends Exception {
-
 }

--- a/src/Model/APIKeyModel.php
+++ b/src/Model/APIKeyModel.php
@@ -19,7 +19,7 @@ class APIKeyModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return APIKey|null - the api key or null if the key could not be saved
 	 */
-	public function create(APIKey $key) : ?APIKey {
+	public function create(APIKey $key): ?APIKey {
 		$connection = $this->configuration()->writable_db_connection();
 		$sql = 'INSERT INTO api_keys (name, token) VALUES (:name, :token)';
 		$statement = $connection->prepare($sql);
@@ -41,7 +41,7 @@ class APIKeyModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return APIKey|null - the api key or null if the key could not be found
 	 */
-	public function read(int $id) : ?APIKey {
+	public function read(int $id): ?APIKey {
 		$connection = $this->configuration()->readonly_db_connection();
 		$sql = 'SELECT id, name, token FROM api_keys WHERE id = :id';
 		$statement = $connection->prepare($sql);
@@ -64,7 +64,7 @@ class APIKeyModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return APIKey|null - the key or null if the key could not be saved
 	 */
-	public function update(APIKey $key) : ?APIKey {
+	public function update(APIKey $key): ?APIKey {
 		$connection = $this->configuration()->writable_db_connection();
 		$sql = 'UPDATE api_keys SET name = :name WHERE id = :id';
 		$statement = $connection->prepare($sql);
@@ -101,7 +101,7 @@ class APIKeyModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return APIKey|null - the api key or null if the key could not be found
 	 */
-	public function delete(int $id) : ?APIKey {
+	public function delete(int $id): ?APIKey {
 		$key = $this->read($id);
 
 		if(NULL !== $key) {
@@ -124,7 +124,7 @@ class APIKeyModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return APIKey[]|null - a list of api keys which match the search query
 	 */
-	public function search(APIKeyQuery $query) : ?array {
+	public function search(APIKeyQuery $query): ?array {
 		if(NULL === $query) {
 			// no query... bail
 			return NULL;
@@ -159,14 +159,14 @@ class APIKeyModel extends AbstractModel {
 		}
 	}
 
-	private function buildAPIKeyFromArray(array $data) : APIKey {
+	private function buildAPIKeyFromArray(array $data): APIKey {
 		return (new APIKey())
 			->set_id($data['id'])
 			->set_name($data['name'])
 			->set_token($data['token']);
 	}
 
-	private function buildAPIKeysFromArrays(array $data) : array {
+	private function buildAPIKeysFromArrays(array $data): array {
 		$keys = array();
 
 		foreach($data as $datum) {

--- a/src/Model/AbstractModel.php
+++ b/src/Model/AbstractModel.php
@@ -27,7 +27,7 @@ class AbstractModel {
 	 *
 	 * @return Config - the configuration to use
 	 */
-	public function configuration() : Config {
+	public function configuration(): Config {
 		return $this->configuration;
 	}
 
@@ -36,7 +36,7 @@ class AbstractModel {
 	 *
 	 * @param Config configuration - the configuration to use
 	 */
-	public function set_configuration(Config $configuration) : void {
+	public function set_configuration(Config $configuration): void {
 		$this->configuration = $configuration;
 	}
 }

--- a/src/Model/CardModel.php
+++ b/src/Model/CardModel.php
@@ -29,7 +29,7 @@ class CardModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Card|null - the card or null if the card could not be saved
 	 */
-	public function create(Card $card) : ?Card {
+	public function create(Card $card): ?Card {
 		$connection = $this->configuration()->writable_db_connection();
 		$sql = 'INSERT INTO cards (id, type_id) VALUES (:id, :type_id)';
 		$query = $connection->prepare($sql);
@@ -88,7 +88,7 @@ class CardModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Card|null - the card or null if the card could not be found
 	 */
-	public function read(int $id) : ?Card {
+	public function read(int $id): ?Card {
 		$connection = $this->configuration()->readonly_db_connection();
 		$sql = 'SELECT c.id, c.type_id, uxc.user_id, etxc.equipment_type_id FROM cards AS c LEFT JOIN users_x_cards AS uxc ON c.id = uxc.card_id LEFT JOIN equipment_type_x_cards AS etxc ON c.id = etxc.card_id WHERE c.id = :id';
 		$query = $connection->prepare($sql);
@@ -111,7 +111,7 @@ class CardModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Card|null - the card or null if the card could not be found
 	 */
-	public function delete(int $id) : ?Card {
+	public function delete(int $id): ?Card {
 		$card = $this->read($id);
 
 		if(NULL !== $card) {
@@ -171,7 +171,7 @@ class CardModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Card[]|null - a list of equipment which match the search query
 	 */
-	public function search(?CardQuery $query = null) : ?array {
+	public function search(?CardQuery $query = null): ?array {
 		$connection = $this->configuration()->readonly_db_connection();
 
 		$sql = 'SELECT c.id, c.type_id, uxc.user_id, etxc.equipment_type_id FROM cards AS c LEFT JOIN users_x_cards AS uxc ON c.id = uxc.card_id LEFT JOIN equipment_type_x_cards AS etxc ON c.id = etxc.card_id';
@@ -212,7 +212,7 @@ class CardModel extends AbstractModel {
 		}
 	}
 
-	private function buildCardFromArray(array $data, array $users, array $equipment_types) : ?Card {
+	private function buildCardFromArray(array $data, array $users, array $equipment_types): ?Card {
 		switch($data['type_id']) {
 			case CardType::PROXY:
 				return (new ProxyCard())->set_id($data['id']);
@@ -250,7 +250,7 @@ class CardModel extends AbstractModel {
 		}
 	}
 
-	private function buildCardsFromArrays(array $data) : array {
+	private function buildCardsFromArrays(array $data): array {
 		$cards = [];
 		$users = [];
 		$roles = [];

--- a/src/Model/CardTypeModel.php
+++ b/src/Model/CardTypeModel.php
@@ -8,7 +8,7 @@ use Portalbox\Exception\DatabaseException;
 use PDO;
 
 class CardTypeModel extends AbstractModel {
-    public function search() : ?array {
+    public function search(): ?array {
         $connection = $this->configuration()->readonly_db_connection();
         $sql = 'SELECT id, name FROM card_types';
         $statement = $connection->prepare($sql);
@@ -24,12 +24,12 @@ class CardTypeModel extends AbstractModel {
         }
     }
 
-    private function buildCardTypesFromArray(array $data) : CardType {
+    private function buildCardTypesFromArray(array $data): CardType {
         return (new CardType())
             ->set_id($data['id']);
     }
 
-    private function buildCardTypesFromArrays(array $data) : array {
+    private function buildCardTypesFromArrays(array $data): array {
         $card_types = array();
 
         foreach($data as $datum) {

--- a/src/Model/ChargeModel.php
+++ b/src/Model/ChargeModel.php
@@ -24,7 +24,7 @@ class ChargeModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Charge|null - the charge or null if the charge could not be saved
 	 */
-	public function create(Charge $charge) : ?Charge {
+	public function create(Charge $charge): ?Charge {
 		$connection = $this->configuration()->writable_db_connection();
 		$sql = 'INSERT INTO charges (user_id, equipment_id, time, amount, charge_policy_id, charge_rate, charged_time) VALUES (:user_id, :equipment_id, :time, :amount, :charge_policy_id, :charge_rate, :charged_time)';
 		$query = $connection->prepare($sql);
@@ -51,7 +51,7 @@ class ChargeModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Charge|null - the charge or null if the charge could not be found
 	 */
-	public function read(int $id) : ?Charge {
+	public function read(int $id): ?Charge {
 		$connection = $this->configuration()->readonly_db_connection();
 		$sql = 'SELECT c.id, c.user_id, u.name AS user_name, c.equipment_id, e.name AS equipment_name, c.time, c.amount, c.charge_policy_id, c.charge_rate, c.charged_time FROM charges AS c INNER JOIN equipment as e ON e.id = c.equipment_id INNER JOIN users AS u on u.id = c.user_id WHERE c.id = :id';
 		$query = $connection->prepare($sql);
@@ -74,7 +74,7 @@ class ChargeModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Charge|null - the charge or null if the charge could not be saved
 	 */
-	public function update(Charge $charge) : ?Charge {
+	public function update(Charge $charge): ?Charge {
 		$connection = $this->configuration()->writable_db_connection();
 		$sql = 'UPDATE charges SET user_id = :user_id, equipment_id = :equipment_id, time = :time, amount = :amount, charge_policy_id = :charge_policy_id, charge_rate = :charge_rate, charged_time = :charged_time WHERE id = :id';
 		$query = $connection->prepare($sql);
@@ -102,7 +102,7 @@ class ChargeModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Charge|null - the charge or null if the charge could not be found
 	 */
-	public function delete(int $id) : ?Charge {
+	public function delete(int $id): ?Charge {
 		$charge = $this->read($id);
 
 		if(NULL !== $charge) {
@@ -125,7 +125,7 @@ class ChargeModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Charge[]|null - a list of charges which match the search query
 	 */
-	public function search(ChargeQuery $query) : ?array {
+	public function search(ChargeQuery $query): ?array {
 		if(NULL === $query) {
 			// no query... bail
 			return NULL;
@@ -191,7 +191,7 @@ class ChargeModel extends AbstractModel {
 		}
 	}
 
-	private function buildChargeFromArray(array $data) : Charge {
+	private function buildChargeFromArray(array $data): Charge {
 		return (new Charge())
 					->set_id($data['id'])
 					->set_user_id($data['user_id'])
@@ -203,7 +203,7 @@ class ChargeModel extends AbstractModel {
 					->set_charged_time($data['charged_time']);
 	}
 
-	private function buildChargesFromArrays(array $data) : array {
+	private function buildChargesFromArrays(array $data): array {
 
 		$charges = [];
 		$machines = [];

--- a/src/Model/Entity/Charge.php
+++ b/src/Model/Entity/Charge.php
@@ -14,7 +14,7 @@ use Portalbox\Model\UserModel;
 class Charge extends AbstractCharge {
 	/**
 	 * The configuration to use
-	 * 
+	 *
 	 * @var Config
 	 */
 	private $configuration;
@@ -33,7 +33,7 @@ class Charge extends AbstractCharge {
 	 */
 	private $user_name;
 
-	
+
 	/**
 	 * @param Config configuration - the configuration to use
 	 */
@@ -46,7 +46,7 @@ class Charge extends AbstractCharge {
 	 *
 	 * @return Config - the configuration to use
 	 */
-	public function configuration() : Config {
+	public function configuration(): Config {
 		return $this->configuration;
 	}
 
@@ -64,16 +64,16 @@ class Charge extends AbstractCharge {
 	 *
 	 * @return string - the name of the equipment the user used to incur the Charge
 	 */
-	public function equipment_name() : ?string {
+	public function equipment_name(): ?string {
 		return $this->equipment_name;
 	}
 
 	/**
 	 * Set the name of the equipment the user used to incur the Charge
-	 * 
+	 *
 	 * @param string name - the name of the equipment the user used to incur the Charge
 	 */
-	public function set_equipment_name(string $equipment_name) : Charge {
+	public function set_equipment_name(string $equipment_name): Charge {
 		$this->equipment_name = $equipment_name;
 		return $this;
 	}
@@ -83,7 +83,7 @@ class Charge extends AbstractCharge {
 	 *
 	 * @return Equipment|null - the equipment the user used to incur the Charge
 	 */
-	public function equipment() : ?Equipment {
+	public function equipment(): ?Equipment {
 		if(NULL === $this->equipment) {
 			$this->equipment = (new EquipmentModel($this->configuration()))->read($this->equipment_id());
 		}
@@ -96,16 +96,16 @@ class Charge extends AbstractCharge {
 	 *
 	 * @return string - the charged user's name
 	 */
-	public function user_name() : ?string {
+	public function user_name(): ?string {
 		return $this->user_name;
 	}
 
 	/**
 	 * Set the charged user's name
-	 * 
+	 *
 	 * @param string name - the charged user's name
 	 */
-	public function set_user_name(?string $user_name) : Charge {
+	public function set_user_name(?string $user_name): Charge {
 		$this->user_name = $user_name;
 		return $this;
 	}
@@ -115,7 +115,7 @@ class Charge extends AbstractCharge {
 	 *
 	 * @return User|null - the charged user
 	 */
-	public function user() : ?User {
+	public function user(): ?User {
 		if(NULL === $this->user) {
 			$this->user = (new UserModel($this->configuration()))->read($this->user_id());
 		}

--- a/src/Model/Entity/Equipment.php
+++ b/src/Model/Entity/Equipment.php
@@ -12,7 +12,7 @@ use Portalbox\Model\LocationModel;
 class Equipment extends AbstractEquipment {
 	/**
 	 * The configuration to use
-	 * 
+	 *
 	 * @var Config
 	 */
 	private $configuration;
@@ -29,7 +29,7 @@ class Equipment extends AbstractEquipment {
 	 *
 	 * @return Config - the configuration to use
 	 */
-	public function configuration() : Config {
+	public function configuration(): Config {
 		return $this->configuration;
 	}
 
@@ -47,7 +47,7 @@ class Equipment extends AbstractEquipment {
 	 *
 	 * @return EquipmentType|null - the equipment's type
 	 */
-	public function type() : ?EquipmentType {
+	public function type(): ?EquipmentType {
 		if(NULL === $this->type) {
 			$this->type = (new EquipmentTypeModel($this->configuration()))->read($this->type_id());
 		}
@@ -60,7 +60,7 @@ class Equipment extends AbstractEquipment {
 	 *
 	 * @return Location|null - the equipment's location
 	 */
-	public function location() : ?Location {
+	public function location(): ?Location {
 		if(NULL === $this->location) {
 			$this->location = (new LocationModel($this->configuration()))->read($this->location_id());
 		}

--- a/src/Model/Entity/User.php
+++ b/src/Model/Entity/User.php
@@ -10,7 +10,7 @@ use Portalbox\Model\RoleModel;
 class User extends AbstractUser {
 	/**
 	 * The configuration to use
-	 * 
+	 *
 	 * @var Config
 	 */
 	private $configuration;
@@ -34,7 +34,7 @@ class User extends AbstractUser {
 	 *
 	 * @return Config - the configuration to use
 	 */
-	public function configuration() : Config {
+	public function configuration(): Config {
 		return $this->configuration;
 	}
 
@@ -43,25 +43,25 @@ class User extends AbstractUser {
 	 *
 	 * @param Config configuration - the configuration to use
 	 */
-	public function set_configuration(Config $configuration) {
+	public function set_configuration(Config $configuration): void {
 		$this->configuration = $configuration;
 	}
 
 	/**
 	 * Get the user's role's name
-	 * 
+	 *
 	 * @return string - the name of the user's role
 	 */
-	public function role_name() : string {
+	public function role_name(): string {
 		return $this->role_name;
 	}
 
 	/**
 	 * Set the user's role's name
-	 * 
+	 *
 	 * @param string name - the name of the user's role
 	 */
-	public function set_role_name(string $name) : User {
+	public function set_role_name(string $name): User {
 		$this->role_name = $name;
 		return $this;
 	}
@@ -71,7 +71,7 @@ class User extends AbstractUser {
 	 *
 	 * @return Role|null - the user's role
 	 */
-	public function role() : ?Role {
+	public function role(): ?Role {
 		if(NULL === $this->role) {
 			$this->role = (new RoleModel($this->configuration()))->read($this->role_id());
 		}

--- a/src/Model/EquipmentModel.php
+++ b/src/Model/EquipmentModel.php
@@ -21,7 +21,7 @@ class EquipmentModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Equipment|null - the equipment or null if the eqipment could not be saved
 	 */
-	public function create(Equipment $equipment) : ?Equipment {
+	public function create(Equipment $equipment): ?Equipment {
 		$connection = $this->configuration()->writable_db_connection();
 		$sql = 'INSERT INTO equipment (name, type_id, mac_address, location_id, timeout, in_service, service_minutes) VALUES (:name, :type_id, :mac_address, :location_id, :timeout, :in_service, :service_minutes)';
 		$query = $connection->prepare($sql);
@@ -50,7 +50,7 @@ class EquipmentModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Equipment|null - the equipment or null if the equipment could not be found
 	 */
-	public function read(int $id) : ?Equipment {
+	public function read(int $id): ?Equipment {
 		$connection = $this->configuration()->readonly_db_connection();
 
 		$sql = 'SELECT e.id, e.name, e.type_id, e.mac_address, e.location_id, e.timeout, e.in_service, iu.equipment_id IS NOT NULL AS in_use, e.service_minutes, e.ip_address FROM equipment AS e LEFT JOIN in_use AS iu ON e.id = iu.equipment_id WHERE e.id = :id';
@@ -77,7 +77,7 @@ class EquipmentModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Equipment|null - the equipment or null if the equipment could not be saved
 	 */
-	public function update(Equipment $equipment) : ?Equipment {
+	public function update(Equipment $equipment): ?Equipment {
 		$connection = $this->configuration()->writable_db_connection();
 		$sql = 'UPDATE equipment SET name = :name, type_id = :type_id, mac_address = :mac_address, location_id = :location_id, timeout = :timeout, in_service = :in_service, service_minutes = :service_minutes WHERE id = :id';
 		$query = $connection->prepare($sql);
@@ -132,7 +132,7 @@ class EquipmentModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Equipment|null - the equipment or null if the equipment could not be found
 	 */
-	public function delete(int $id) : ?Equipment {
+	public function delete(int $id): ?Equipment {
 		$equipment = $this->read($id);
 
 		if(NULL !== $equipment) {
@@ -155,7 +155,7 @@ class EquipmentModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Equipment[]|null - a list of equipment which match the search query
 	 */
-	public function search(EquipmentQuery $query) : ?array {
+	public function search(EquipmentQuery $query): ?array {
 		if(NULL === $query) {
 			// no query... bail
 			return NULL;
@@ -216,7 +216,7 @@ class EquipmentModel extends AbstractModel {
 		}
 	}
 
-	private function buildEquipmentFromArray(array $data) : Equipment {
+	private function buildEquipmentFromArray(array $data): Equipment {
 		return (new PDOAwareEquipment($this->configuration()))
 					->set_id($data['id'])
 					->set_name($data['name'])
@@ -230,7 +230,7 @@ class EquipmentModel extends AbstractModel {
 					->set_ip_address($data['ip_address']);
 	}
 
-	private function buildEquipmentFromArrays(array $data) : array {
+	private function buildEquipmentFromArrays(array $data): array {
 		$equipment = [];
 
 		foreach($data as $datum) {

--- a/src/Model/EquipmentTypeModel.php
+++ b/src/Model/EquipmentTypeModel.php
@@ -18,7 +18,7 @@ class EquipmentTypeModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return EquipmentType|null - the equipment type or null if the type could not be saved
 	 */
-	public function create(EquipmentType $type) : ?EquipmentType {
+	public function create(EquipmentType $type): ?EquipmentType {
 		$connection = $this->configuration()->writable_db_connection();
 		$sql = 'INSERT INTO equipment_types (name, requires_training, charge_rate, charge_policy_id, allow_proxy) VALUES (:name, :requires_training, :charge_rate, :charge_policy_id, :allow_proxy)';
 		$query = $connection->prepare($sql);
@@ -43,7 +43,7 @@ class EquipmentTypeModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return EquipmentType|null - the equipment type or null if the type could not be found
 	 */
-	public function read(int $id) : ?EquipmentType {
+	public function read(int $id): ?EquipmentType {
 		$connection = $this->configuration()->readonly_db_connection();
 		$sql = 'SELECT id, name, requires_training, charge_rate, charge_policy_id, allow_proxy FROM equipment_types WHERE id = :id';
 		$query = $connection->prepare($sql);
@@ -66,7 +66,7 @@ class EquipmentTypeModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return EquipmentType|null - the equipment type or null if the equipment type could not be saved
 	 */
-	public function update(EquipmentType $type) : ?EquipmentType {
+	public function update(EquipmentType $type): ?EquipmentType {
 		$connection = $this->configuration()->writable_db_connection();
 		$sql = 'UPDATE equipment_types SET name = :name, requires_training = :requires_training, charge_rate = :charge_rate, charge_policy_id = :charge_policy_id, allow_proxy = :allow_proxy WHERE id = :id';
 		$query = $connection->prepare($sql);
@@ -92,7 +92,7 @@ class EquipmentTypeModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return EquipmentType|null - the equipment type or null if the equipment type could not be found
 	 */
-	public function delete(int $id) : ?EquipmentType {
+	public function delete(int $id): ?EquipmentType {
 		$type = $this->read($id);
 
 		if(NULL !== $type) {
@@ -114,7 +114,7 @@ class EquipmentTypeModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Location[]|null - a list of locations
 	 */
-	public function search() : ?array {
+	public function search(): ?array {
 
 		$connection = $this->configuration()->readonly_db_connection();
 		$sql = 'SELECT id, name, requires_training, charge_policy_id, charge_rate, allow_proxy FROM equipment_types ORDER BY name';
@@ -131,7 +131,7 @@ class EquipmentTypeModel extends AbstractModel {
 		}
 	}
 
-	private function buildEquipmentTypeFromArray(array $data) : EquipmentType {
+	private function buildEquipmentTypeFromArray(array $data): EquipmentType {
 		return (new EquipmentType())
 					->set_id($data['id'])
 					->set_name($data['name'])
@@ -141,7 +141,7 @@ class EquipmentTypeModel extends AbstractModel {
 					->set_allow_proxy($data['allow_proxy']);
 	}
 
-	private function buildEquipmentTypesFromArrays(array $data) : array {
+	private function buildEquipmentTypesFromArrays(array $data): array {
 		$locations = array();
 
 		foreach($data as $datum) {

--- a/src/Model/LocationModel.php
+++ b/src/Model/LocationModel.php
@@ -18,7 +18,7 @@ class LocationModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Location|null - the location or null if the location could not be saved
 	 */
-	public function create(Location $location) : ?Location {
+	public function create(Location $location): ?Location {
 		$connection = $this->configuration()->writable_db_connection();
 		$sql = 'INSERT INTO locations (name) VALUES (:name)';
 		$query = $connection->prepare($sql);
@@ -39,7 +39,7 @@ class LocationModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Location|null - the location or null if the location could not be found
 	 */
-	public function read(int $id) : ?Location {
+	public function read(int $id): ?Location {
 		$connection = $this->configuration()->readonly_db_connection();
 		$sql = 'SELECT id, name FROM locations WHERE id = :id';
 		$query = $connection->prepare($sql);
@@ -62,7 +62,7 @@ class LocationModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Location|null - the location or null if the location could not be saved
 	 */
-	public function update(Location $location) : ?Location {
+	public function update(Location $location): ?Location {
 		$connection = $this->configuration()->writable_db_connection();
 		$sql = 'UPDATE locations SET name = :name WHERE id = :id';
 		$query = $connection->prepare($sql);
@@ -84,7 +84,7 @@ class LocationModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Location|null - the location or null if the location could not be found
 	 */
-	public function delete(int $id) : ?Location {
+	public function delete(int $id): ?Location {
 		$location = $this->read($id);
 
 		if(NULL !== $location) {
@@ -106,7 +106,7 @@ class LocationModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Location[]|null - a list of locations
 	 */
-	public function search() : ?array {
+	public function search(): ?array {
 
 		$connection = $this->configuration()->readonly_db_connection();
 
@@ -124,13 +124,13 @@ class LocationModel extends AbstractModel {
 		}
 	}
 
-	private function buildLocationFromArray(array $data) : Location {
+	private function buildLocationFromArray(array $data): Location {
 		return (new Location())
 					->set_id($data['id'])
 					->set_name($data['name']);
 	}
 
-	private function buildLocationsFromArrays(array $data) : array {
+	private function buildLocationsFromArrays(array $data): array {
 		$locations = array();
 
 		foreach($data as $datum) {

--- a/src/Model/LoggedEventModel.php
+++ b/src/Model/LoggedEventModel.php
@@ -21,7 +21,7 @@ class LoggedEventModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return LoggedEvent|null - the location or null if the location could not be found
 	 */
-	public function read(int $id) : ?LoggedEvent {
+	public function read(int $id): ?LoggedEvent {
 		$connection = $this->configuration()->readonly_db_connection();
 		$sql = <<<EOQ
 		SELECT
@@ -68,7 +68,7 @@ class LoggedEventModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return LoggedEvent[]|null - a list of logged events
 	 */
-	public function search(LoggedEventQuery $query) : ?array {
+	public function search(LoggedEventQuery $query): ?array {
 		if(NULL === $query) {
 			// no query... bail
 			return NULL;
@@ -149,7 +149,7 @@ class LoggedEventModel extends AbstractModel {
 		}
 	}
 
-	private function buildLoggedEventFromArray(array $data) : LoggedEvent {
+	private function buildLoggedEventFromArray(array $data): LoggedEvent {
 		return (new PDOAwareLoggedEvent($this->configuration()))
 			->set_id($data['id'])
 			->set_type_id($data['event_type_id'])
@@ -164,7 +164,7 @@ class LoggedEventModel extends AbstractModel {
 			->set_user_name($data['user_name']);
 	}
 
-	private function buildLoggedEventsFromArray(array $data) : array {
+	private function buildLoggedEventsFromArray(array $data): array {
 		$log = array();
 
 		foreach($data as $datum) {

--- a/src/Model/PaymentModel.php
+++ b/src/Model/PaymentModel.php
@@ -19,7 +19,7 @@ class PaymentModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Payment|null - the payment or null if the payment could not be saved
 	 */
-	public function create(Payment $payment) : ?Payment {
+	public function create(Payment $payment): ?Payment {
 		$connection = $this->configuration()->writable_db_connection();
 		$sql = 'INSERT INTO payments (user_id, amount, time) VALUES (:user_id, :amount, :time)';
 		$query = $connection->prepare($sql);
@@ -42,7 +42,7 @@ class PaymentModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Payment|null - the payment or null if the payment could not be found
 	 */
-	public function read(int $id) : ?Payment {
+	public function read(int $id): ?Payment {
 		$connection = $this->configuration()->readonly_db_connection();
 		$sql = 'SELECT id, user_id, amount, time FROM payments WHERE id = :id';
 		$query = $connection->prepare($sql);
@@ -65,7 +65,7 @@ class PaymentModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Payment|null - the payment or null if the payment could not be saved
 	 */
-	public function update(Payment $payment) : ?Payment {
+	public function update(Payment $payment): ?Payment {
 		$connection = $this->configuration()->writable_db_connection();
 		$sql = 'UPDATE payments SET user_id = :user_id, amount = :amount, time = :time WHERE id = :id';
 		$query = $connection->prepare($sql);
@@ -89,7 +89,7 @@ class PaymentModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Payment|null - the payment or null if the payment could not be found
 	 */
-	public function delete(int $id) : ?Payment {
+	public function delete(int $id): ?Payment {
 		$payment = $this->read($id);
 
 		if(NULL !== $payment) {
@@ -112,7 +112,7 @@ class PaymentModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Payment[]|null - a list of payments which match the search query
 	 */
-	public function search(PaymentQuery $query) : ?array {
+	public function search(PaymentQuery $query): ?array {
 		if(NULL === $query) {
 			// no query... bail
 			return NULL;
@@ -158,7 +158,7 @@ class PaymentModel extends AbstractModel {
 		}
 	}
 
-	private function buildPaymentFromArray(array $data) : Payment {
+	private function buildPaymentFromArray(array $data): Payment {
 		return (new Payment())
 				->set_id($data['id'])
 				->set_user_id($data['user_id'])
@@ -166,7 +166,7 @@ class PaymentModel extends AbstractModel {
 				->set_time($data['time']);
 	}
 
-	private function buildPaymentsFromArrays(array $data) : array {
+	private function buildPaymentsFromArrays(array $data): array {
 		$payments = array();
 
 		foreach($data as $datum) {

--- a/src/Model/RoleModel.php
+++ b/src/Model/RoleModel.php
@@ -18,7 +18,7 @@ class RoleModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Role|null - the role or null if the role could not be saved
 	 */
-	public function create(Role $role) : ?Role {
+	public function create(Role $role): ?Role {
 		$connection = $this->configuration()->writable_db_connection();
 		$sql = 'INSERT INTO roles (name, is_system_role, description) VALUES (:name, :is_system_role, :description)';
 		$statement = $connection->prepare($sql);
@@ -69,7 +69,7 @@ class RoleModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Role|null - the role or null if the role could not be found
 	 */
-	public function read(int $id) : ?Role {
+	public function read(int $id): ?Role {
 		$connection = $this->configuration()->readonly_db_connection();
 		$sql = 'SELECT id, name, is_system_role, description FROM roles WHERE id = :id';
 		$statement = $connection->prepare($sql);
@@ -102,7 +102,7 @@ class RoleModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Role|null - the role or null if the role could not be saved
 	 */
-	public function update(Role $role) : Role {
+	public function update(Role $role): Role {
 		$role_id = $role->id();
 		$old_permissions = $this->read($role_id)->permissions();
 
@@ -171,7 +171,7 @@ class RoleModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Role|null - the role or null if the role could not be deleted
 	 */
-	public function delete(int $id) : ?Role {
+	public function delete(int $id): ?Role {
 		$role = $this->read($id);
 
 		if(NULL !== $role) {
@@ -198,7 +198,7 @@ class RoleModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Role[]|null - a list of role which match the search query
 	 */
-	public function search() : ?array {
+	public function search(): ?array {
 		$connection = $this->configuration()->readonly_db_connection();
 		$sql = 'SELECT id, name, is_system_role, description FROM roles';
 		$statement = $connection->prepare($sql);
@@ -214,7 +214,7 @@ class RoleModel extends AbstractModel {
 		}
 	}
 
-	private function buildRoleFromArray(array $data) : Role {
+	private function buildRoleFromArray(array $data): Role {
 		return (new Role())
 					->set_id($data['id'])
 					->set_name($data['name'])
@@ -222,7 +222,7 @@ class RoleModel extends AbstractModel {
 					->set_description($data['description']);
 	}
 
-	private function buildRolesFromArrays(array $data) : array {
+	private function buildRolesFromArrays(array $data): array {
 		$roles = array();
 
 		foreach($data as $datum) {

--- a/src/Model/UserModel.php
+++ b/src/Model/UserModel.php
@@ -20,7 +20,7 @@ class UserModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return User|null - the user or null if the user could not be saved
 	 */
-	public function create(User $user) : ?User {
+	public function create(User $user): ?User {
 		$connection = $this->configuration()->writable_db_connection();
 		$sql = 'INSERT INTO users (name, email, comment, role_id, is_active) VALUES (:name, :email, :comment, :role_id, :is_active)';
 		$statement = $connection->prepare($sql);
@@ -72,7 +72,7 @@ class UserModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return User|null - the user or null if the user could not be found
 	 */
-	public function read(int $id) : ?User {
+	public function read(int $id): ?User {
 		$connection = $this->configuration()->readonly_db_connection();
 		$sql = 'SELECT u.id, u.name, u.email, u.comment, u.is_active, u.role_id, r.name AS role FROM users AS u INNER JOIN roles AS r ON u.role_id = r.id WHERE u.id = :id';
 		$statement = $connection->prepare($sql);
@@ -104,7 +104,7 @@ class UserModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return User|null - the user or null if the user could not be saved
 	 */
-	public function update(User $user) : ?User {
+	public function update(User $user): ?User {
 		$user_id = $user->id();
 		$authorizations = $user->authorizations();
 		$old_authorizations = $this->read($user_id)->authorizations();
@@ -183,7 +183,7 @@ class UserModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return User|null - the user or null if the user could not be found
 	 */
-	public function delete(int $id) : ?User {
+	public function delete(int $id): ?User {
 		$user = $this->read($id);
 
 		if(NULL !== $user) {
@@ -207,7 +207,7 @@ class UserModel extends AbstractModel {
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return User[]|null - a list of users which match the search query
 	 */
-	public function search(UserQuery $query) : ?array {
+	public function search(UserQuery $query): ?array {
 		if(NULL === $query) {
 			// no query... bail
 			return NULL;
@@ -269,7 +269,7 @@ class UserModel extends AbstractModel {
 		}
 	}
 
-	private function buildUserFromArray(array $data) : User {
+	private function buildUserFromArray(array $data): User {
 		return (new PDOAwareUser($this->configuration()))
 					->set_id($data['id'])
 					->set_name($data['name'])
@@ -280,7 +280,7 @@ class UserModel extends AbstractModel {
 					->set_role_name($data['role']);
 	}
 
-	private function buildUsersFromArrays(array $data) : array {
+	private function buildUsersFromArrays(array $data): array {
 		$users = array();
 
 		foreach($data as $datum) {

--- a/src/Query/APIKeyQuery.php
+++ b/src/Query/APIKeyQuery.php
@@ -18,7 +18,7 @@ class APIKeyQuery {
 	 *
 	 * @return string|null - the token for which to search
 	 */
-	public function token() : ?string {
+	public function token(): ?string {
 
 		return $this->token;
 	}
@@ -29,7 +29,7 @@ class APIKeyQuery {
 	 * @param string token - the token for which to search
 	 * @return self
 	 */
-	public function set_token(string $token) : self {
+	public function set_token(string $token): self {
 
 		$this->token = $token;
 		return $this;

--- a/src/Query/CardQuery.php
+++ b/src/Query/CardQuery.php
@@ -32,7 +32,7 @@ class CardQuery {
 	 *
 	 * @return int - the equipment type id
 	 */
-	public function equipment_type_id() : ?int {
+	public function equipment_type_id(): ?int {
 		return $this->equipment_type_id;
 	}
 
@@ -42,7 +42,7 @@ class CardQuery {
 	 * @param int equipment_type_id - the equipment id
 	 * @return self
 	 */
-	public function set_equipment_type_id(int $type_id) : self {
+	public function set_equipment_type_id(int $type_id): self {
 		$this->equipment_type_id = $type_id;
 		return $this;
 	}
@@ -52,7 +52,7 @@ class CardQuery {
 	 *
 	 * @return int - the user id
 	 */
-	public function user_id() : ?int {
+	public function user_id(): ?int {
 		return $this->user_id;
 	}
 
@@ -62,7 +62,7 @@ class CardQuery {
 	 * @param int user_id - the user id
 	 * @return self
 	 */
-	public function set_user_id(int $user_id) : self {
+	public function set_user_id(int $user_id): self {
 		$this->user_id = $user_id;
 		return $this;
 	}
@@ -72,7 +72,7 @@ class CardQuery {
 	 *
 	 * @return int - the card id
 	 */
-	public function id() : ?int  {
+	public function id(): ?int  {
 		return $this->id;
 	}
 

--- a/src/Query/ChargeQuery.php
+++ b/src/Query/ChargeQuery.php
@@ -40,7 +40,7 @@ class ChargeQuery {
 	 *
 	 * @return string - the on or before date
 	 */
-	public function on_or_before() : ?string {
+	public function on_or_before(): ?string {
 		return $this->on_or_before;
 	}
 
@@ -50,7 +50,7 @@ class ChargeQuery {
 	 * @param string on_or_before - the on or before date
 	 * @return self
 	 */
-	public function set_on_or_before(string $on_or_before) : self {
+	public function set_on_or_before(string $on_or_before): self {
 		$this->on_or_before = $on_or_before;
 		return $this;
 	}
@@ -60,7 +60,7 @@ class ChargeQuery {
 	 *
 	 * @return string - the on or after date
 	 */
-	public function on_or_after() : ?string {
+	public function on_or_after(): ?string {
 		return $this->on_or_after;
 	}
 
@@ -70,7 +70,7 @@ class ChargeQuery {
 	 * @param string on_or_after - the on or after date
 	 * @return self
 	 */
-	public function set_on_or_after(string $on_or_after) : self {
+	public function set_on_or_after(string $on_or_after): self {
 		$this->on_or_after = $on_or_after;
 		return $this;
 	}
@@ -80,7 +80,7 @@ class ChargeQuery {
 	 *
 	 * @return int - the equipment id
 	 */
-	public function equipment_id() : ?int {
+	public function equipment_id(): ?int {
 		return $this->equipment_id;
 	}
 
@@ -90,7 +90,7 @@ class ChargeQuery {
 	 * @param int equipment_id - the equipment id
 	 * @return self
 	 */
-	public function set_equipment_id(int $equipment_id) : self {
+	public function set_equipment_id(int $equipment_id): self {
 		$this->equipment_id = $equipment_id;
 		return $this;
 	}
@@ -100,7 +100,7 @@ class ChargeQuery {
 	 *
 	 * @return int - the user id
 	 */
-	public function user_id() : ?int {
+	public function user_id(): ?int {
 		return $this->user_id;
 	}
 
@@ -110,7 +110,7 @@ class ChargeQuery {
 	 * @param int user_id - the user id
 	 * @return self
 	 */
-	public function set_user_id(int $user_id) : self {
+	public function set_user_id(int $user_id): self {
 		$this->user_id = $user_id;
 		return $this;
 	}

--- a/src/Query/EquipmentQuery.php
+++ b/src/Query/EquipmentQuery.php
@@ -6,137 +6,72 @@ namespace Portalbox\Query;
  * EquipmentQuery presents a standard interface for Equipment search queries
  */
 class EquipmentQuery {
-	/**
-	 * Whether to find out of service equipment
-	 *
-	 * @var bool
-	 */
-	protected $include_out_of_service;
+	/** Whether to find out of service equipment */
+	protected bool $include_out_of_service = false;
 
-	/**
-	 * Find equipment by named type
-	 *
-	 * @var string|null
-	 */
-	protected $type;
+	/** Find equipment by named type */
+	protected ?string $type = null;
 
-	/**
-	 * Find equipment in the named location
-	 *
-	 * @var string|null
-	 */
-	protected $location;
+	/** Find equipment in the named location */
+	protected ?string $location = null;
 
-	/**
-	 * Find equipment in the location by id
-	 *
-	 * @var int|null
-	 */
-	protected $location_id;
+	/** Find equipment in the location by id */
+	protected ?int $location_id = null;
 
-	/**
-	 * Create a new Equipment Query by default excluding out of service equipment
-	 */
-	public function __construct() {
-		$this->set_include_out_of_service(false);
-	}
+	/** The ip address of the portalbox attached to the equipment */
+	protected ?string $ip_address = null;
 
-	/**
-	 * Get whether to find out of service equipment
-	 *
-	 * @return bool - whether to find out of service equipment
-	 */
-	public function include_out_of_service() : bool {
+	/** Get whether to find out of service equipment */
+	public function include_out_of_service(): bool {
 		return $this->include_out_of_service;
 	}
 
-	/**
-	 * Set whether to find out of service equipment
-	 *
-	 * @param bool include_out_of_service - whether to find out of service equipment
-	 * @return self
-	 */
-	public function set_include_out_of_service(bool $include_out_of_service) : self {
+	/** Set whether to find out of service equipment */
+	public function set_include_out_of_service(bool $include_out_of_service): self {
 		$this->include_out_of_service = $include_out_of_service;
 		return $this;
 	}
 
-	/**
-	 * Get the type
-	 *
-	 * @return string|null - the name of the equipment type
-	 */
-	public function type() : ?string {
+	/** Get the type */
+	public function type(): ?string {
 		return $this->type;
 	}
 
-	/**
-	 * Set the name of the equipmen type
-	 *
-	 * @param string|null type - the name of the equipment type
-	 * @return self
-	 */
-	public function set_type(?string $type) : self {
+	/** Set the name of the equipmen type */
+	public function set_type(?string $type): self {
 		$this->type = $type;
 		return $this;
 	}
 
-	/**
-	 * Get the location
-	 *
-	 * @return string|null - the name of the location
-	 */
-	public function location() : ?string {
+	/** Get the location */
+	public function location(): ?string {
 		return $this->location;
 	}
 
-	/**
-	 * Set the location name
-	 *
-	 * @param string|null location - the location name
-	 * @return self
-	 */
-	public function set_location(?string $location) : self {
+	/** Set the location name */
+	public function set_location(?string $location): self {
 		$this->location = $location;
 		return $this;
 	}
 
-	/**
-	 * Get the location id
-	 *
-	 * @return int|null - the location id
-	 */
-	public function location_id() : ?int {
+	/** Get the location id */
+	public function location_id(): ?int {
 		return $this->location_id;
 	}
 
-	/**
-	 * Set the location id
-	 *
-	 * @param int|null location_id - the location id
-	 * @return self
-	 */
-	public function set_location_id(?int $location_id) : self {
+	/** Set the location id */
+	public function set_location_id(?int $location_id): self {
 		$this->location_id = $location_id;
 		return $this;
 	}
 
-		/**
-	 * Get the ip address
-	 *
-	 * @return string|null - the ip address
-	 */
-	public function ip_address() : ?string {
+	/** Get the ip address */
+	public function ip_address(): ?string {
 		return $this->ip_address;
 	}
 
-	/**
-	 * Set the ip address
-	 *
-	 * @param string|null ip_address - the ip address
-	 * @return self
-	 */
-	public function set_ip_address(?string $ip_address) : self {
+	/** Set the ip address */
+	public function set_ip_address(?string $ip_address): self {
 		$this->ip_address = $ip_address;
 		return $this;
 	}

--- a/src/Query/LoggedEventQuery.php
+++ b/src/Query/LoggedEventQuery.php
@@ -53,7 +53,7 @@ class LoggedEventQuery {
 	 *
 	 * @return string - the on or before date
 	 */
-	public function on_or_before() : ?string {
+	public function on_or_before(): ?string {
 		return $this->on_or_before;
 	}
 
@@ -63,7 +63,7 @@ class LoggedEventQuery {
 	 * @param string on_or_before - the on or before date
 	 * @return self
 	 */
-	public function set_on_or_before(string $on_or_before) : self {
+	public function set_on_or_before(string $on_or_before): self {
 		$this->on_or_before = $on_or_before;
 		return $this;
 	}
@@ -73,7 +73,7 @@ class LoggedEventQuery {
 	 *
 	 * @return string - the on or after date
 	 */
-	public function on_or_after() : ?string {
+	public function on_or_after(): ?string {
 		return $this->on_or_after;
 	}
 
@@ -83,7 +83,7 @@ class LoggedEventQuery {
 	 * @param string on_or_after - the on or after date
 	 * @return self
 	 */
-	public function set_on_or_after(string $on_or_after) : self {
+	public function set_on_or_after(string $on_or_after): self {
 		$this->on_or_after = $on_or_after;
 		return $this;
 	}
@@ -93,7 +93,7 @@ class LoggedEventQuery {
 	 *
 	 * @return int - the equipment id
 	 */
-	public function equipment_id() : ?int {
+	public function equipment_id(): ?int {
 		return $this->equipment_id;
 	}
 
@@ -103,7 +103,7 @@ class LoggedEventQuery {
 	 * @param int equipment_id - the equipment id
 	 * @return self
 	 */
-	public function set_equipment_id(int $equipment_id) : self {
+	public function set_equipment_id(int $equipment_id): self {
 		$this->equipment_id = $equipment_id;
 		return $this;
 	}
@@ -113,7 +113,7 @@ class LoggedEventQuery {
 	 *
 	 * @return int - the location id
 	 */
-	public function location_id() : ?int {
+	public function location_id(): ?int {
 		return $this->location_id;
 	}
 
@@ -123,7 +123,7 @@ class LoggedEventQuery {
 	 * @param int location_id - the location id
 	 * @return self
 	 */
-	public function set_location_id(int $location_id) : self {
+	public function set_location_id(int $location_id): self {
 		$this->location_id = $location_id;
 		return $this;
 	}
@@ -133,7 +133,7 @@ class LoggedEventQuery {
 	 *
 	 * @return int - the type id
 	 */
-	public function type_id() : ?int {
+	public function type_id(): ?int {
 		return $this->type_id;
 	}
 
@@ -143,7 +143,7 @@ class LoggedEventQuery {
 	 * @param int type_id - the type id
 	 * @return self
 	 */
-	public function set_type_id(int $type_id) : self {
+	public function set_type_id(int $type_id): self {
 		$this->type_id = $type_id;
 		return $this;
 	}
@@ -153,7 +153,7 @@ class LoggedEventQuery {
 	 *
 	 * @return int - the equipment type id
 	 */
-	public function equipment_type_id() : ?int {
+	public function equipment_type_id(): ?int {
 		return $this->equipment_type_id;
 	}
 
@@ -163,7 +163,7 @@ class LoggedEventQuery {
 	 * @param int equipment_type_id - the equipment type id
 	 * @return self
 	 */
-	public function set_equipment_type_id(int $equipment_type_id) : self {
+	public function set_equipment_type_id(int $equipment_type_id): self {
 		$this->equipment_type_id = $equipment_type_id;
 		return $this;
 	}

--- a/src/Query/PaymentQuery.php
+++ b/src/Query/PaymentQuery.php
@@ -32,7 +32,7 @@ class PaymentQuery {
 	 *
 	 * @return string - the on or before date
 	 */
-	public function on_or_before() : ?string {
+	public function on_or_before(): ?string {
 		return $this->on_or_before;
 	}
 
@@ -42,7 +42,7 @@ class PaymentQuery {
 	 * @param string on_or_before - the on or before date
 	 * @return self
 	 */
-	public function set_on_or_before(string $on_or_before) : self {
+	public function set_on_or_before(string $on_or_before): self {
 		$this->on_or_before = $on_or_before;
 		return $this;
 	}
@@ -52,7 +52,7 @@ class PaymentQuery {
 	 *
 	 * @return string - the on or after date
 	 */
-	public function on_or_after() : ?string {
+	public function on_or_after(): ?string {
 		return $this->on_or_after;
 	}
 
@@ -62,7 +62,7 @@ class PaymentQuery {
 	 * @param string on_or_after - the on or after date
 	 * @return self
 	 */
-	public function set_on_or_after(string $on_or_after) : self {
+	public function set_on_or_after(string $on_or_after): self {
 		$this->on_or_after = $on_or_after;
 		return $this;
 	}
@@ -72,7 +72,7 @@ class PaymentQuery {
 	 *
 	 * @return int - the user id
 	 */
-	public function user_id() : ?int {
+	public function user_id(): ?int {
 		return $this->user_id;
 	}
 
@@ -82,7 +82,7 @@ class PaymentQuery {
 	 * @param int user_id - the user id
 	 * @return self
 	 */
-	public function set_user_id(int $user_id) : self {
+	public function set_user_id(int $user_id): self {
 		$this->user_id = $user_id;
 		return $this;
 	}

--- a/src/Query/UserQuery.php
+++ b/src/Query/UserQuery.php
@@ -60,7 +60,7 @@ class UserQuery {
 	 *
 	 * @return string|null - the email address of the user for which to search
 	 */
-	public function email() : ?string {
+	public function email(): ?string {
 		return $this->email;
 	}
 
@@ -70,7 +70,7 @@ class UserQuery {
 	 * @param string email - the email address of the user for which to search
 	 * @return self
 	 */
-	public function set_email(string $email) : self {
+	public function set_email(string $email): self {
 		$this->email = $email;
 		return $this;
 	}
@@ -80,7 +80,7 @@ class UserQuery {
 	 *
 	 * @return string|null - the name of the user for which to search
 	 */
-	public function name() : ?string {
+	public function name(): ?string {
 		return $this->name;
 	}
 
@@ -90,7 +90,7 @@ class UserQuery {
 	 * @param string email - the name of the user for which to search
 	 * @return self
 	 */
-	public function set_name(string $name) : self {
+	public function set_name(string $name): self {
 		$this->name = $name;
 		return $this;
 	}
@@ -100,7 +100,7 @@ class UserQuery {
 	 *
 	 * @return string|null
 	 */
-	public function comment() : ?string {
+	public function comment(): ?string {
 		return $this->comment;
 	}
 	/**
@@ -109,7 +109,7 @@ class UserQuery {
 	 * @param string comment
 	 * @return self
 	 */
-	public function set_comment(string $comment) : self {
+	public function set_comment(string $comment): self {
 		$this->comment = $comment;
 		return $this;
 	}
@@ -119,7 +119,7 @@ class UserQuery {
 	 *
 	 * @return int|null
 	 */
-	public function equipment_id() : ?int {
+	public function equipment_id(): ?int {
 		return $this->equipment_id;
 	}
 
@@ -129,25 +129,25 @@ class UserQuery {
 	 * @param int equipment id
 	 * @return self
 	 */
-	public function set_equipment_id(int $equipment_id) : self {
+	public function set_equipment_id(int $equipment_id): self {
 		$this->equipment_id = $equipment_id;
 		return $this;
 	}
 
-	public function include_inactive() : ?int {
+	public function include_inactive(): ?int {
 		return $this->include_inactive;
 	}
 
-	public function set_include_inactive(int $include_inactive) : self {
+	public function set_include_inactive(int $include_inactive): self {
 		$this->include_inactive = $include_inactive;
 		return $this;
 	}
 
-	public function role_id() : ?int {
+	public function role_id(): ?int {
 		return $this->role_id;
 	}
 
-	public function set_role_id(int $role_id) : self {
+	public function set_role_id(int $role_id): self {
 		$this->role_id = $role_id;
 		return $this;
 	}

--- a/src/Session.php
+++ b/src/Session.php
@@ -26,38 +26,38 @@ class Session {
 	 * @return User|null - the currently authenticated user or null if there
 	 *     is not a currently authenticated user
 	 */
-	public static function get_authenticated_user() : ?User {
+	public static function get_authenticated_user(): ?User {
 		if(!self::$authenticated_user) {
-			
+
 			$config = Config::config();
-			
+
 			// Check for Brearer token
 			if(array_key_exists('HTTP_AUTHORIZATION', $_SERVER) &&
 				8 < strlen($_SERVER['HTTP_AUTHORIZATION']) &&
 				0 == strcmp('Bearer ', substr($_SERVER['HTTP_AUTHORIZATION'], 0 , 7))) {
 				$token = substr($_SERVER['HTTP_AUTHORIZATION'], 7);
-				
+
 
 				$model = new APIKeyModel($config);
-				
+
 				$query = (new APIKeyQuery)->set_token($token);
-				
+
 				$keys = $model->search($query);
-				
+
 				if($keys && 0 < count($keys)) {
 					// get key 0 and construct a fake user for it.
 					self::$authenticated_user = (new PDOAwareUser($config))
 						->set_name($keys[0]->name())
 						->set_is_active(true)
-						->set_role_id(3);	// API key act as admins... 
+						->set_role_id(3);	// API key act as admins...
 											// in future should add a role_id field
 											// to keys and restrict them accordingly
 
 					return self::$authenticated_user;
 				}
 			}
-			
-			// Check for cookie based session 
+
+			// Check for cookie based session
 			if(PHP_SESSION_ACTIVE !== session_status()) {
 				$success = session_start();
 				if(!$success) {
@@ -93,14 +93,14 @@ class Session {
 	 * A convenience method that returns true iff the user is authenticated and
 	 * has the specified permission. An HTTP 403 response will be sent and
 	 * script execution terminated if the user is not authenticated.
-	 * 
+	 *
 	 * @param int permission the Permission for which to check. Must be one of
 	 *     the constants exposed in Portalbox\Entity\Permission to result in
 	 *     true being returned
 	 * @return bool true iff the User is authenticated and has the specified
 	 *     permission
 	 */
-	public static function check_authorization(int $permission) : bool {
+	public static function check_authorization(int $permission): bool {
 		self::require_authentication();
 
 		return self::get_authenticated_user()->role()->has_permission($permission);

--- a/src/Trait/HasIdProperty.php
+++ b/src/Trait/HasIdProperty.php
@@ -14,14 +14,14 @@ trait HasIdProperty {
 	/**
 	 * Get the id of this entity
 	 */
-	public function id() : ?int {
+	public function id(): ?int {
 		return $this->id;
 	}
 
 	/**
 	 * Set the unique id of this entity
 	 */
-	public function set_id(?int $id) : self {
+	public function set_id(?int $id): self {
 		$this->id = $id;
 		return $this;
 	}

--- a/src/Transform/APIKeyTransformer.php
+++ b/src/Transform/APIKeyTransformer.php
@@ -17,7 +17,7 @@ class APIKeyTransformer implements InputTransformer, OutputTransformer {
 	 * @return APIKey - a valid entity object based on the data specified
 	 * @throws InvalidArgumentException if a require field is not specified
 	 */
-	public function deserialize(array $data) : APIKey {
+	public function deserialize(array $data): APIKey {
 		if(!array_key_exists('name', $data)) {
 			throw new InvalidArgumentException('\'name\' is a required field');
 		}
@@ -36,7 +36,7 @@ class APIKeyTransformer implements InputTransformer, OutputTransformer {
 	 *      restrictions when $traverse is true or a dictionary whose values
 	 *      are null, string, int, and float otherwise
 	 */
-	public function serialize($data, bool $traverse = false) : array {
+	public function serialize($data, bool $traverse = false): array {
 		if($traverse) {
 			return [
 				'id' => $data->id(),
@@ -59,7 +59,7 @@ class APIKeyTransformer implements InputTransformer, OutputTransformer {
 	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
-	public function get_column_headers() : array {
+	public function get_column_headers(): array {
 		return ['id', 'Name', 'Token'];
 	}
 }

--- a/src/Transform/AuthorizationsTransformer.php
+++ b/src/Transform/AuthorizationsTransformer.php
@@ -21,7 +21,7 @@ class AuthorizationsTransformer implements InputTransformer {
 	 * @return array<int> - a list of authorization ids
 	 * @throws InvalidArgumentException if a required field is not specified
 	 */
-	public function deserialize(array $data) : array {
+	public function deserialize(array $data): array {
 		if(!array_key_exists('authorizations', $data)) {
 			throw new InvalidArgumentException('\'authorizations\' is a required field');
 		}

--- a/src/Transform/CardTransformer.php
+++ b/src/Transform/CardTransformer.php
@@ -29,7 +29,7 @@ class CardTransformer implements InputTransformer, OutputTransformer {
 	 * @return Card - a valid entity object based on the data specified
 	 * @throws InvalidArgumentException if a require field is not specified
 	 */
-	public function deserialize(array $data) : Card {
+	public function deserialize(array $data): Card {
 		if(!array_key_exists('id', $data)) {
 			throw new InvalidArgumentException('\'id\' is a required field');
 		}
@@ -77,7 +77,7 @@ class CardTransformer implements InputTransformer, OutputTransformer {
 	 *      restrictions when $traverse is true or a dictionary whose values
 	 *      are null, string, int, and float otherwise
 	 */
-	public function serialize($data, bool $traverse = false) : array {
+	public function serialize($data, bool $traverse = false): array {
 		$card_type_id = $data->type_id();
 
 		if($traverse) {
@@ -168,7 +168,7 @@ class CardTransformer implements InputTransformer, OutputTransformer {
 	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
-	public function get_column_headers() : array {
+	public function get_column_headers(): array {
 		return ['id', 'Card Type ID', 'Card Type', 'User ID', 'User', 'Equipment Type ID', 'Equipment Type'];
 	}
 }

--- a/src/Transform/CardTypeTransformer.php
+++ b/src/Transform/CardTypeTransformer.php
@@ -6,7 +6,7 @@ use InvalidArgumentException;
 use Portalbox\Entity\CardType;
 
 class CardTypeTransformer implements InputTransformer, OutputTransformer {
-    public function deserialize(array $data) : CardType {
+    public function deserialize(array $data): CardType {
         if(!array_key_exists('id', $data)) {
             throw new InvalidArgumentException('\'id\' is a required field');
         }
@@ -15,7 +15,7 @@ class CardTypeTransformer implements InputTransformer, OutputTransformer {
             ->set_id($data['id']);
     }
 
-    public function serialize($data, bool $traverse = false) : array {
+    public function serialize($data, bool $traverse = false): array {
         if($traverse) {
             return [
                 'id' => $data->id(),
@@ -29,7 +29,7 @@ class CardTypeTransformer implements InputTransformer, OutputTransformer {
         }
     }
 
-    public function get_column_headers() : array {
+    public function get_column_headers(): array {
         return ['id', 'Name'];
     }
 }

--- a/src/Transform/ChargeTransformer.php
+++ b/src/Transform/ChargeTransformer.php
@@ -25,7 +25,7 @@ class ChargeTransformer implements InputTransformer, OutputTransformer {
 	 * @return Charge - a valid entity object based on the data specified
 	 * @throws InvalidArgumentException if a require field is not specified
 	 */
-	public function deserialize(array $data) : Charge {
+	public function deserialize(array $data): Charge {
 		if(!array_key_exists('equipment_id', $data)) {
 			throw new InvalidArgumentException('\'equipment_id\' is a required field');
 		}
@@ -80,7 +80,7 @@ class ChargeTransformer implements InputTransformer, OutputTransformer {
 	 *      restrictions when $traverse is true or a dictionary whose values
 	 *      are null, string, int, and float otherwise
 	 */
-	public function serialize($data, bool $traverse = false) : array {
+	public function serialize($data, bool $traverse = false): array {
 		if($traverse) {
 			$equipment_transformer = new EquipmentTransformer();
 			$user_transformer = new UserTransformer();
@@ -119,7 +119,7 @@ class ChargeTransformer implements InputTransformer, OutputTransformer {
 	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
-	public function get_column_headers() : array {
+	public function get_column_headers(): array {
 		return ['id', 'Equipment ID', 'Equipment', 'User ID', 'User', 'Amount', 'Time', 'Charge Policy ID', 'Charge Policy', 'Charge Rate', 'Charged Time'];
 	}
 }

--- a/src/Transform/ConfigOutputTransformer.php
+++ b/src/Transform/ConfigOutputTransformer.php
@@ -8,7 +8,6 @@ use DomainException;
  * ConfigTransformer is our bridge between the Config and the outputable portion
  */
 class ConfigOutputTransformer implements OutputTransformer {
-
 	/**
 	 * Called to serialize a Config
 	 *
@@ -19,7 +18,7 @@ class ConfigOutputTransformer implements OutputTransformer {
 	 *      restrictions when $traverse is true or a dictionary whose values
 	 *      are null, string, int, and float otherwise
 	 */
-	public function serialize($config, bool $traverse = false) : array {
+	public function serialize($config, bool $traverse = false): array {
 		return $config->web_ui_settings();
 	}
 
@@ -30,7 +29,7 @@ class ConfigOutputTransformer implements OutputTransformer {
 	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
-	public function get_column_headers() : array {
+	public function get_column_headers(): array {
 		throw new DomainException('Data does not support this operation');
 	}
 }

--- a/src/Transform/EquipmentTransformer.php
+++ b/src/Transform/EquipmentTransformer.php
@@ -24,7 +24,7 @@ class EquipmentTransformer implements InputTransformer, OutputTransformer {
 	 * @return Equipment - a valid entity object based on the data specified
 	 * @throws InvalidArgumentException if a require field is not specified
 	 */
-	public function deserialize(array $data) : Equipment {
+	public function deserialize(array $data): Equipment {
 		if(!array_key_exists('name', $data)) {
 			throw new InvalidArgumentException('\'name\' is a required field');
 		}
@@ -79,7 +79,7 @@ class EquipmentTransformer implements InputTransformer, OutputTransformer {
 	 *      restrictions when $traverse is true or a dictionary whose values
 	 *      are null, string, int, and float otherwise
 	 */
-	public function serialize($data, bool $traverse = false) : array {
+	public function serialize($data, bool $traverse = false): array {
 		if($traverse) {
 			return [
 				'id' => $data->id(),
@@ -118,7 +118,7 @@ class EquipmentTransformer implements InputTransformer, OutputTransformer {
 	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
-	public function get_column_headers() : array {
+	public function get_column_headers(): array {
 		return ['id', 'Name', 'Type', 'MAC Address', 'Location', 'Timeout', 'In Service', 'In Use', 'Service Minutes'];
 	}
 }

--- a/src/Transform/EquipmentTypeTransformer.php
+++ b/src/Transform/EquipmentTypeTransformer.php
@@ -19,7 +19,7 @@ class EquipmentTypeTransformer implements InputTransformer, OutputTransformer {
 	 * @return EquipmentType - a valid entity object based on the data specified
 	 * @throws InvalidArgumentException if a require field is not specified
 	 */
-	public function deserialize(array $data) : EquipmentType {
+	public function deserialize(array $data): EquipmentType {
 		if(!array_key_exists('name', $data)) {
 			throw new InvalidArgumentException('\'name\' is a required field');
 		}
@@ -58,7 +58,7 @@ class EquipmentTypeTransformer implements InputTransformer, OutputTransformer {
 	 *      restrictions when $traverse is true or a dictionary whose values
 	 *      are null, string, int, and float otherwise
 	 */
-	public function serialize($data, bool $traverse = false) : array {
+	public function serialize($data, bool $traverse = false): array {
 		if($traverse) {
 			return [
 				'id' => $data->id(),
@@ -88,7 +88,7 @@ class EquipmentTypeTransformer implements InputTransformer, OutputTransformer {
 	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
-	public function get_column_headers() : array {
+	public function get_column_headers(): array {
 		return ['id', 'Name', 'Requires Training', 'Charge Rate', 'Charge Policy', "Allow Proxy"];
 	}
 }

--- a/src/Transform/InputTransformer.php
+++ b/src/Transform/InputTransformer.php
@@ -7,10 +7,8 @@ namespace Portalbox\Transform;
  * instance from the data
  */
 interface InputTransformer {
-
 	/**
 	 * Get get an Entity instance from a serialized blob of data
 	 */
 	public function deserialize(array $data);
-
 }

--- a/src/Transform/LocationTransformer.php
+++ b/src/Transform/LocationTransformer.php
@@ -18,7 +18,7 @@ class LocationTransformer implements InputTransformer, OutputTransformer {
 	 * @return Location - a valid entity object based on the data specified
 	 * @throws InvalidArgumentException if a require field is not specified
 	 */
-	public function deserialize(array $data) : Location {
+	public function deserialize(array $data): Location {
 		if(!array_key_exists('name', $data)) {
 			throw new InvalidArgumentException('\'name\' is a required field');
 		}
@@ -36,7 +36,7 @@ class LocationTransformer implements InputTransformer, OutputTransformer {
 	 *      restrictions when $traverse is true or a dictionary whose values
 	 *      are null, string, int, and float otherwise
 	 */
-	public function serialize($data, bool $traverse = false) : array {
+	public function serialize($data, bool $traverse = false): array {
 		if($traverse) {
 			return [
 				'id' => $data->id(),
@@ -57,7 +57,7 @@ class LocationTransformer implements InputTransformer, OutputTransformer {
 	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
-	public function get_column_headers() : array {
+	public function get_column_headers(): array {
 		return ['id', 'Name'];
 	}
 }

--- a/src/Transform/LoggedEventTransformer.php
+++ b/src/Transform/LoggedEventTransformer.php
@@ -18,7 +18,7 @@ class LoggedEventTransformer implements OutputTransformer {
 	 *      restrictions when $traverse is true or a dictionary whose values
 	 *      are null, string, int, and float otherwise
 	 */
-	public function serialize($data, bool $traverse = false) : array {
+	public function serialize($data, bool $traverse = false): array {
 		if($traverse) {
 			$equipment_transformer = new EquipmentTransformer();
 			$user_transformer = new UserTransformer();
@@ -51,7 +51,7 @@ class LoggedEventTransformer implements OutputTransformer {
 	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
-	public function get_column_headers() : array {
+	public function get_column_headers(): array {
 		return ['id', 'Time', 'Type', 'Card', 'User', 'Equipment Name', 'Equipment Type', 'Location'];
 	}
 }

--- a/src/Transform/NullOutputTransformer.php
+++ b/src/Transform/NullOutputTransformer.php
@@ -9,7 +9,6 @@ use DomainException;
  * Transformed into a variety of output encodings
  */
 class NullOutputTransformer implements OutputTransformer {
-
 	/**
 	 * Called to serialize a non-entity
 	 *
@@ -20,7 +19,7 @@ class NullOutputTransformer implements OutputTransformer {
 	 *      restrictions when $traverse is true or a dictionary whose values
 	 *      are null, string, int, and float otherwise
 	 */
-	public function serialize($data, bool $traverse = false) : array {
+	public function serialize($data, bool $traverse = false): array {
 		return $data;
 
 	}
@@ -32,7 +31,7 @@ class NullOutputTransformer implements OutputTransformer {
 	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
-	public function get_column_headers() : array {
+	public function get_column_headers(): array {
 		throw new DomainException('Data does not support this operation');
 	}
 }

--- a/src/Transform/OutputTransformer.php
+++ b/src/Transform/OutputTransformer.php
@@ -27,7 +27,7 @@ interface OutputTransformer {
 	 *      restrictions when $traverse is true or a dictionary whose values
 	 *      are null, string, int, and float otherwise
 	 */
-	public function serialize($data, bool $traverse = false) : array;
+	public function serialize($data, bool $traverse = false): array;
 
 	/**
 	 * Called to get the column headers for a tabular output format eg csv.
@@ -36,5 +36,5 @@ interface OutputTransformer {
 	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
-	public function get_column_headers() : array;
+	public function get_column_headers(): array;
 }

--- a/src/Transform/PaymentTransformer.php
+++ b/src/Transform/PaymentTransformer.php
@@ -23,7 +23,7 @@ class PaymentTransformer implements InputTransformer, OutputTransformer {
 	 * @return Payment - a valid entity object based on the data specified
 	 * @throws InvalidArgumentException if a require field is not specified
 	 */
-	public function deserialize(array $data) : Payment {
+	public function deserialize(array $data): Payment {
 		if(!array_key_exists('user_id', $data)) {
 			throw new InvalidArgumentException('\'user_id\' is a required field');
 		}
@@ -55,7 +55,7 @@ class PaymentTransformer implements InputTransformer, OutputTransformer {
 	 *      restrictions when $traverse is true or a dictionary whose values
 	 *      are null, string, int, and float otherwise
 	 */
-	public function serialize($data, bool $traverse = false) : array {
+	public function serialize($data, bool $traverse = false): array {
 		if($traverse) {
 			return [
 				'id' => $data->id(),
@@ -80,7 +80,7 @@ class PaymentTransformer implements InputTransformer, OutputTransformer {
 	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
-	public function get_column_headers() : array {
+	public function get_column_headers(): array {
 		return ['id', 'User Id', 'Amount', 'Time'];
 	}
 }

--- a/src/Transform/RoleTransformer.php
+++ b/src/Transform/RoleTransformer.php
@@ -17,7 +17,7 @@ class RoleTransformer implements InputTransformer, OutputTransformer {
 	 * @return Role - a valid entity object based on the data specified
 	 * @throws InvalidArgumentException if a require field is not specified
 	 */
-	public function deserialize(array $data) : Role {
+	public function deserialize(array $data): Role {
 		if(!array_key_exists('name', $data)) {
 			throw new InvalidArgumentException('\'name\' is a required field');
 		}
@@ -45,7 +45,7 @@ class RoleTransformer implements InputTransformer, OutputTransformer {
 	 *      restrictions when $traverse is true or a dictionary whose values
 	 *      are null, string, int, and float otherwise
 	 */
-	public function serialize($data, bool $traverse = false) : array {
+	public function serialize($data, bool $traverse = false): array {
 		if($traverse) {
 			return [
 				'id' => $data->id(),
@@ -71,7 +71,7 @@ class RoleTransformer implements InputTransformer, OutputTransformer {
 	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
-	public function get_column_headers() : array {
+	public function get_column_headers(): array {
 		return ['id', 'Name', 'System Role', 'Description'];
 	}
 }

--- a/src/Transform/UserTransformer.php
+++ b/src/Transform/UserTransformer.php
@@ -24,7 +24,7 @@ class UserTransformer implements InputTransformer, OutputTransformer {
 	 * @return Payment - a valid entity object based on the data specified
 	 * @throws InvalidArgumentException if a require field is not specified
 	 */
-	public function deserialize(array $data) : User {
+	public function deserialize(array $data): User {
 		if(!array_key_exists('role_id', $data)) {
 			throw new InvalidArgumentException('\'role_id\' is a required field');
 		}
@@ -82,7 +82,7 @@ class UserTransformer implements InputTransformer, OutputTransformer {
 	 *      restrictions when $traverse is true or a dictionary whose values
 	 *      are null, string, int, and float otherwise
 	 */
-	public function serialize($data, bool $traverse = false) : array {
+	public function serialize($data, bool $traverse = false): array {
 		if($traverse) {
 			$role_transformer = new RoleTransformer();
 			return [
@@ -113,7 +113,7 @@ class UserTransformer implements InputTransformer, OutputTransformer {
 	 *
 	 * @return array - a list of strings that ccan be column headers
 	 */
-	public function get_column_headers() : array {
+	public function get_column_headers(): array {
 		return ['id', 'Name', 'Email', 'Comment', 'Role', 'Active'];
 	}
 }

--- a/test/Model/CardModelTest.php
+++ b/test/Model/CardModelTest.php
@@ -98,7 +98,7 @@ final class CardModelTest extends TestCase {
 		self::$user = $model->create($user);
 	}
 
-	public static function tearDownAfterClass() : void {
+	public static function tearDownAfterClass(): void {
 		// deprovision a location in the db
 		$model = new LocationModel(self::$config);
 		$model->delete(self::$location->id());

--- a/test/Model/ChargeModelTest.php
+++ b/test/Model/ChargeModelTest.php
@@ -119,7 +119,7 @@ final class ChargeModelTest extends TestCase {
 		self::$equipment = $model->create($equipment);
 	}
 
-	public static function tearDownAfterClass() : void {
+	public static function tearDownAfterClass(): void {
 		// deprovision a location in the db
 		$model = new UserModel(self::$config);
 		$model->delete(self::$user->id());

--- a/test/Model/EquipmentModelTest.php
+++ b/test/Model/EquipmentModelTest.php
@@ -61,7 +61,7 @@ final class EquipmentModelTest extends TestCase {
 		self::$type = $model->create($type);
 	}
 
-	public static function tearDownAfterClass() : void {
+	public static function tearDownAfterClass(): void {
 		// deprovision a location in the db
 		$model = new LocationModel(self::$config);
 		$model->delete(self::$location->id());

--- a/test/Model/LoggedEventModelTest.php
+++ b/test/Model/LoggedEventModelTest.php
@@ -108,7 +108,7 @@ final class LoggedEventModelTest extends TestCase {
 		);
 	}
 
-	public static function tearDownAfterClass() : void {
+	public static function tearDownAfterClass(): void {
 		$model = new CardModel(self::$config);
 		$model->delete(self::$card->id());
 

--- a/test/Model/PaymentModelTest.php
+++ b/test/Model/PaymentModelTest.php
@@ -51,7 +51,7 @@ final class PaymentModelTest extends TestCase {
 		self::$user = $model->create($user);
 	}
 
-	public static function tearDownAfterClass() : void {
+	public static function tearDownAfterClass(): void {
 		$model = new UserModel(self::$config);
 		$model->delete(self::$user->id());
 

--- a/test/Model/UserModelTest.php
+++ b/test/Model/UserModelTest.php
@@ -48,7 +48,7 @@ final class UserModelTest extends TestCase {
 		self::$type = $model->create($type);
 	}
 
-	public static function tearDownAfterClass() : void {
+	public static function tearDownAfterClass(): void {
 		// deprovision an equipment type in the db
 		$model = new EquipmentTypeModel(self::$config);
 		$model->delete(self::$type->id());

--- a/test/Transform/ChargeTransformerTest.php
+++ b/test/Transform/ChargeTransformerTest.php
@@ -119,7 +119,7 @@ final class ChargeTransformerTest extends TestCase {
 		self::$equipment = $model->create($equipment);
 	}
 
-	public static function tearDownAfterClass() : void {
+	public static function tearDownAfterClass(): void {
 		$config = Config::config();
 
 		// deprovision user from the db

--- a/test/Transform/EquipmentTransformerTest.php
+++ b/test/Transform/EquipmentTransformerTest.php
@@ -61,7 +61,7 @@ final class EquipmentTransformerTest extends TestCase {
 		self::$type = $model->create($type);
 	}
 
-	public static function tearDownAfterClass() : void {
+	public static function tearDownAfterClass(): void {
 		$config = Config::config();
 
 		// deprovision equipment type from the db

--- a/test/Transform/LoggedEventTransformerTest.php
+++ b/test/Transform/LoggedEventTransformerTest.php
@@ -120,7 +120,7 @@ final class LoggedEventTransformerTest extends TestCase {
 		self::$equipment = $model->create($equipment);
 	}
 
-	public static function tearDownAfterClass() : void {
+	public static function tearDownAfterClass(): void {
 		$config = Config::config();
 
 		// deprovision user from the db

--- a/test/Transform/PaymentTransformerTest.php
+++ b/test/Transform/PaymentTransformerTest.php
@@ -48,7 +48,7 @@ final class PaymentTransformerTest extends TestCase {
 		self::$user = $model->create($user);
 	}
 
-	public static function tearDownAfterClass() : void {
+	public static function tearDownAfterClass(): void {
 		$config = Config::config();
 
 		// deprovision user from the db

--- a/test/Transform/UserTransformerTest.php
+++ b/test/Transform/UserTransformerTest.php
@@ -41,7 +41,7 @@ final class UserTransformerTest extends TestCase {
 		self::$type = $model->create($type);
 	}
 
-	public static function tearDownAfterClass() : void {
+	public static function tearDownAfterClass(): void {
 		// deprovision an equipment type in the db
 		$model = new EquipmentTypeModel(Config::config());
 		$model->delete(self::$type->id());


### PR DESCRIPTION
This PR if accepted adopts the [PSR-12](https://www.php-fig.org/psr/psr-12/) guidance not to put a space between the ) and : in a method signature when specifying a return type.