### PR TITLE
chore: moving towards adopting PSR-12 coding standard for PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ You should take care to prevent the contents of the `config` directory from bein
 
 Since 2019 Tom Egan <tom@tomegan.tech>
 
+## Contributing
+
+We welcome contributes. Please open a Pull Request (PR) and request review from @mlamparter or @tkegan
+
+We would prefer if you used our coding standards but are in the process of formalizing them so if unsure check the "allow maintainers to modify PR" checkbox when creating your PR and we'll help you out.
+
 ## Roadmap
 
 - modernize code
@@ -119,3 +125,4 @@ Since 2019 Tom Egan <tom@tomegan.tech>
 - add a way to set a logo other than editing index.html
 - add visualizations of usage data
 - automate Integration testing with Bruno
+- document coding standards for PHP (PSR-12 except with cuddled braces and tab indents) and Javascript (ESlint baseline except with tab indents)

--- a/composer.json
+++ b/composer.json
@@ -2,16 +2,17 @@
     "name": "bucknell/portalbox",
     "type": "project",
     "require-dev": {
-        "phpunit/phpunit": "^9.1"
+        "phpunit/phpunit": "^9.6",
+        "squizlabs/php_codesniffer": "^3.11"
     },
     "license": "apache2.0",
     "require": {
         "ext-pdo": "*",
         "ext-json": "*"
     },
-    "autoload" : {
+    "autoload": {
         "psr-4": {
-            "Portalbox\\" : "src/"
+            "Portalbox\\": "src/"
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,34 +4,35 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f04c8335130af3893f76a6b90af95cbd",
+    "content-hash": "66d4ed4e281f6cdb5bcaca085c3b34a9",
     "packages": [],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.4.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^8.0",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
-                "phpstan/phpstan": "^0.12",
-                "phpstan/phpstan-phpunit": "^0.12",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -56,6 +57,10 @@
                 "constructor",
                 "instantiate"
             ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+            },
             "funding": [
                 {
                     "url": "https://www.doctrine-project.org/sponsorship.html",
@@ -70,41 +75,43 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-10T18:47:58+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.10.2",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
+                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/123267b2c49fbf30d78a7b2d333f6be754b94845",
+                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
             },
             "require-dev": {
-                "doctrine/collections": "^1.0",
-                "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^7.1"
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -118,35 +125,41 @@
                 "object",
                 "object graph"
             ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.1"
+            },
             "funding": [
                 {
                     "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-13T09:40:50+00:00"
+            "time": "2024-11-08T17:47:46+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.10.3",
+            "version": "v5.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dbe56d23de8fcb157bbc0cfb3ad7c7de0cfb0984"
+                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dbe56d23de8fcb157bbc0cfb3ad7c7de0cfb0984",
-                "reference": "dbe56d23de8fcb157bbc0cfb3ad7c7de0cfb0984",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
+                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.0"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -154,7 +167,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.9-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -176,24 +189,29 @@
                 "parser",
                 "php"
             ],
-            "time": "2020-12-03T17:45:45+00:00"
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
+            },
+            "time": "2024-12-30T11:07:19+00:00"
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.1",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133"
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-phar": "*",
                 "ext-xmlwriter": "*",
                 "phar-io/version": "^3.0.1",
@@ -232,20 +250,30 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2020-06-27T14:33:11+00:00"
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "3.0.3",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "726c026815142e4f8677b7cb7f2249c9ffb7ecae"
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/726c026815142e4f8677b7cb7f2249c9ffb7ecae",
-                "reference": "726c026815142e4f8677b7cb7f2249c9ffb7ecae",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
                 "shasum": ""
             },
             "require": {
@@ -279,257 +307,52 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2020-11-30T09:21:21+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-common",
-            "version": "2.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
-                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
-            "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
-            ],
-            "time": "2020-06-27T09:03:43+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "5.2.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
-                "shasum": ""
-            },
-            "require": {
-                "ext-filter": "*",
-                "php": "^7.2 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.2",
-                "phpdocumentor/type-resolver": "^1.3",
-                "webmozart/assert": "^1.9.1"
-            },
-            "require-dev": {
-                "mockery/mockery": "~1.3.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                },
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "account@ijaap.nl"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2020-09-03T19:13:55+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "1.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
-                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.0"
-            },
-            "require-dev": {
-                "ext-tokenizer": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "time": "2020-09-17T18:55:26+00:00"
-        },
-        {
-            "name": "phpspec/prophecy",
-            "version": "1.12.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/8ce87516be71aae9b956f81906aaf0338e0d8a2d",
-                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.2",
-                "php": "^7.2 || ~8.0, <8.1",
-                "phpdocumentor/reflection-docblock": "^5.2",
-                "sebastian/comparator": "^3.0 || ^4.0",
-                "sebastian/recursion-context": "^3.0 || ^4.0"
-            },
-            "require-dev": {
-                "phpspec/phpspec": "^6.0",
-                "phpunit/phpunit": "^8.0 || ^9.0 <9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.11.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Prophecy\\": "src/Prophecy"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Konstantin Kudryashov",
-                    "email": "ever.zet@gmail.com",
-                    "homepage": "http://everzet.com"
-                },
-                {
-                    "name": "Marcello Duarte",
-                    "email": "marcello.duarte@gmail.com"
-                }
-            ],
-            "description": "Highly opinionated mocking framework for PHP 5.3+",
-            "homepage": "https://github.com/phpspec/prophecy",
-            "keywords": [
-                "Double",
-                "Dummy",
-                "fake",
-                "mock",
-                "spy",
-                "stub"
-            ],
-            "time": "2020-09-29T09:10:42+00:00"
+            "time": "2022-02-21T01:04:05+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.5",
+            "version": "9.2.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1"
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f3e026641cc91909d421802dd3ac7827ebfd97e1",
-                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.10.2",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
                 "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
-                "theseer/tokenizer": "^1.2.0"
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^9.6"
             },
             "suggest": {
-                "ext-pcov": "*",
-                "ext-xdebug": "*"
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "9.2.x-dev"
                 }
             },
             "autoload": {
@@ -555,26 +378,31 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:44:49+00:00"
+            "time": "2024-08-22T04:23:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.5",
+            "version": "3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8"
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/aa4be8575f26070b100fccb67faabb28f21f66f8",
-                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
                 "shasum": ""
             },
             "require": {
@@ -611,13 +439,17 @@
                 "filesystem",
                 "iterator"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:57:25+00:00"
+            "time": "2021-12-02T12:48:52+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -670,6 +502,10 @@
             "keywords": [
                 "process"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -725,6 +561,10 @@
             "keywords": [
                 "template"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -780,6 +620,10 @@
             "keywords": [
                 "timer"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -790,55 +634,50 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.0",
+            "version": "9.6.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "8e16c225d57c3d6808014df6b1dd7598d0a5bbbe"
+                "reference": "f80235cb4d3caa59ae09be3adf1ded27521d1a9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/8e16c225d57c3d6808014df6b1dd7598d0a5bbbe",
-                "reference": "8e16c225d57c3d6808014df6b1dd7598d0a5bbbe",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f80235cb4d3caa59ae09be3adf1ded27521d1a9c",
+                "reference": "f80235cb4d3caa59ae09be3adf1ded27521d1a9c",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1",
+                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.1",
-                "phar-io/version": "^3.0.2",
+                "myclabs/deep-copy": "^1.12.1",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
-                "phpspec/prophecy": "^1.12.1",
-                "phpunit/php-code-coverage": "^9.2.3",
-                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
                 "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.5",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.3",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^2.3",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.8",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.6",
+                "sebastian/global-state": "^5.0.7",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
                 "sebastian/version": "^3.0.2"
             },
-            "require-dev": {
-                "ext-pdo": "*",
-                "phpspec/prophecy-phpunit": "^2.0.1"
-            },
             "suggest": {
-                "ext-soap": "*",
-                "ext-xdebug": "*"
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "bin": [
                 "phpunit"
@@ -846,15 +685,15 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.5-dev"
+                    "dev-master": "9.6-dev"
                 }
             },
             "autoload": {
-                "classmap": [
-                    "src/"
-                ],
                 "files": [
                     "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -875,30 +714,39 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.22"
+            },
             "funding": [
                 {
-                    "url": "https://phpunit.de/donate.html",
+                    "url": "https://phpunit.de/sponsors.html",
                     "type": "custom"
                 },
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2020-12-04T05:05:53+00:00"
+            "time": "2024-12-05T13:48:26+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
                 "shasum": ""
             },
             "require": {
@@ -931,13 +779,17 @@
             ],
             "description": "Library for parsing CLI options",
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:08:49+00:00"
+            "time": "2024-03-02T06:27:43+00:00"
         },
         {
             "name": "sebastian/code-unit",
@@ -983,6 +835,10 @@
             ],
             "description": "Collection of value objects that represent the PHP code units",
             "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1034,6 +890,10 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1044,16 +904,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.6",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "55f4261989e546dc112258c7a75935a81a7ce382"
+                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55f4261989e546dc112258c7a75935a81a7ce382",
-                "reference": "55f4261989e546dc112258c7a75935a81a7ce382",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
+                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
                 "shasum": ""
             },
             "require": {
@@ -1104,30 +964,34 @@
                 "compare",
                 "equality"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:49:45+00:00"
+            "time": "2022-09-14T12:41:17+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.2",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.7",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3"
             },
             "require-dev": {
@@ -1157,26 +1021,30 @@
             ],
             "description": "Library for calculating the complexity of PHP code units",
             "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:52:27+00:00"
+            "time": "2023-12-22T06:19:30+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.4",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
                 "shasum": ""
             },
             "require": {
@@ -1219,26 +1087,30 @@
                 "unidiff",
                 "unified diff"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:10:38+00:00"
+            "time": "2024-03-02T06:30:58+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.3",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "388b6ced16caa751030f6a69e588299fa09200ac"
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/388b6ced16caa751030f6a69e588299fa09200ac",
-                "reference": "388b6ced16caa751030f6a69e588299fa09200ac",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
                 "shasum": ""
             },
             "require": {
@@ -1278,26 +1150,30 @@
                 "environment",
                 "hhvm"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:52:38+00:00"
+            "time": "2023-02-03T06:03:51+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.3",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65"
+                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/d89cc98761b8cb5a1a235a6b703ae50d34080e65",
-                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/78c00df8f170e02473b682df15bfcdacc3d32d72",
+                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72",
                 "shasum": ""
             },
             "require": {
@@ -1346,31 +1222,35 @@
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.6"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:24:23+00:00"
+            "time": "2024-03-02T06:33:00+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.2",
+            "version": "5.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455"
+                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/a90ccbddffa067b51f574dea6eb25d5680839455",
-                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
                 "shasum": ""
             },
             "require": {
@@ -1411,30 +1291,34 @@
             "keywords": [
                 "global state"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:55:19+00:00"
+            "time": "2024-03-02T06:35:11+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.6",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3"
             },
             "require-dev": {
@@ -1464,13 +1348,17 @@
             ],
             "description": "Library for counting the lines of code in PHP source code",
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:42:11+00:00"
+            "time": "2023-12-22T06:20:34+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -1517,6 +1405,10 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1568,6 +1460,10 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1578,16 +1474,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
                 "shasum": ""
             },
             "require": {
@@ -1626,27 +1522,31 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:17:30+00:00"
+            "time": "2023-02-03T06:07:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
                 "shasum": ""
             },
             "require": {
@@ -1658,7 +1558,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1678,38 +1578,41 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:45:17+00:00"
+            "time": "2024-03-14T16:00:52+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "2.3.1",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2"
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
-                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^9.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1730,13 +1633,17 @@
             ],
             "description": "Collection of value objects that represent the types of the PHP type system",
             "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:18:59+00:00"
+            "time": "2023-02-03T06:13:03+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1779,6 +1686,10 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1788,93 +1699,97 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.20.0",
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.11.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41"
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "1368f4a58c3c52114b86b1abe8f4098869cb0079"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f4ba089a5b6366e453971d3aad5fe8e897b37f41",
-                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/1368f4a58c3c52114b86b1abe8f4098869cb0079",
+                "reference": "1368f4a58c3c52114b86b1abe8f4098869cb0079",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
             },
-            "suggest": {
-                "ext-ctype": "For best performance"
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
                 },
                 {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
+                "phpcs",
+                "standards",
+                "static analysis"
             ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
             "funding": [
                 {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
+                    "url": "https://github.com/PHPCSStandards",
                     "type": "github"
                 },
                 {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
                 }
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "time": "2024-12-11T16:04:26+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.0",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
                 "shasum": ""
             },
             "require": {
@@ -1901,73 +1816,28 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/theseer",
                     "type": "github"
                 }
             ],
-            "time": "2020-07-12T23:59:07+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.9.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0 || ^8.0",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<3.9.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "time": "2020-07-08T17:02:28+00:00"
+            "time": "2024-03-03T12:36:25+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "ext-pdo": "*",
         "ext-json": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
+    <description>The Portalbox coding standard.</description>
+
+    <file>src</file>
+    <file>test</file>
+
+    <arg name="basepath" value="."/>
+    <arg name="colors"/>
+    <arg name="parallel" value="75"/>
+    <arg value="np"/>
+
+    <!-- Don't hide tokenizer exceptions -->
+    <rule ref="Internal.Tokenizer.Exception">
+        <type>error</type>
+    </rule>
+
+    <!-- PSR-12 is our starting point -->
+    <rule ref="PSR12">
+        <exclude name="PSR12.Traits.UseDeclaration.UseAfterBrace" />
+    </rule>
+    <rule ref="PSR2">
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine" />
+        <exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine" />
+        <exclude name="PSR2.ControlStructures.ControlStructureSpacing" />
+        <exclude name="Generic.WhiteSpace.DisallowTabIndent"/>
+    </rule>
+    <rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie" />
+    <rule ref="Generic.Classes.OpeningBraceSameLine" />
+    <arg name="tab-width" value="4"/>
+    <rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
+    <rule ref="Generic.WhiteSpace.ScopeIndent">
+        <properties>
+            <property name="indent" value="4"/>
+            <property name="tabIndent" value="true"/>
+        </properties>
+    </rule>
+</ruleset>

--- a/public/index.html
+++ b/public/index.html
@@ -1,31 +1,46 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8">
-		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-		<meta name="theme-color" content="#FF9900">
-		<link rel="manifest" href="/manifest.json">
-		<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png">
-		<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png">
-		<link rel="shortcut icon" href="/images/favicon.ico">
-		<script src="/vendor/hellojs/dist/hello.all.min.js"></script>
-		<script src="/vendor/mustache/mustache.min.js"></script>
-		<script src="/vendor/moostaka/dist/moostaka.min.js"></script>
-		<script src="/vendor/file-saver/dist/FileSaver.min.js"></script>
-		<link rel="stylesheet" href="/styles/palette.css">
-		<link rel="stylesheet" href="/styles/common.css">
-		<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-		<title>MakerPortal</title>
-	</head>
-	<body>
-		<header>
-			<h1><a href="/">Maker Portal</a></h1>
-			<div id="page-menu"></div>
-		</header>
-		<main id="main">
-			<noscript>You need to enable JavaScript to run this app.</noscript>
-			<div class="spinner"></div>
-		</main>
-		<script type="module" src="/js/main.js"></script>
-	</body>
+    <head>
+        <meta charset="utf-8" />
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1, shrink-to-fit=no"
+        />
+        <meta name="theme-color" content="#FF9900" />
+        <link rel="manifest" href="/manifest.json" />
+        <link
+            rel="icon"
+            type="image/png"
+            sizes="32x32"
+            href="/images/favicon-32x32.png"
+        />
+        <link
+            rel="icon"
+            type="image/png"
+            sizes="16x16"
+            href="/images/favicon-16x16.png"
+        />
+        <link rel="shortcut icon" href="/images/favicon.ico" />
+        <script src="/vendor/hellojs/dist/hello.all.min.js"></script>
+        <script src="/vendor/mustache/mustache.min.js"></script>
+        <script src="/vendor/file-saver/dist/FileSaver.min.js"></script>
+        <link rel="stylesheet" href="/styles/palette.css" />
+        <link rel="stylesheet" href="/styles/common.css" />
+        <link
+            href="https://fonts.googleapis.com/icon?family=Material+Icons"
+            rel="stylesheet"
+        />
+        <title>MakerPortal</title>
+    </head>
+    <body>
+        <header>
+            <h1><a href="/">Maker Portal</a></h1>
+            <div id="page-menu"></div>
+        </header>
+        <main id="main">
+            <noscript>You need to enable JavaScript to run this app.</noscript>
+            <div class="spinner"></div>
+        </main>
+        <script type="module" src="/js/main.js"></script>
+    </body>
 </html>

--- a/src/Config.php
+++ b/src/Config.php
@@ -34,7 +34,7 @@ class Config {
 	 */
 	public function __construct($file = '../config/config.ini') {
 		$path = realpath(__DIR__ . DIRECTORY_SEPARATOR . $file);
-		$this->settings = parse_ini_file($path, TRUE);
+		$this->settings = parse_ini_file($path, true);
 	}
 
 	/**
@@ -43,7 +43,7 @@ class Config {
 	 * @return Config - the singleton configuration
 	 */
 	public static function config(): Config {
-		if(!self::$instance) {
+		if (!self::$instance) {
 			self::$instance = new Config();
 		}
 
@@ -60,7 +60,7 @@ class Config {
 	private function connection(): PDO {
 		$connection = null;
 
-		if(FALSE != $this->settings && array_key_exists('database', $this->settings)) {
+		if (false != $this->settings && array_key_exists('database', $this->settings)) {
 			// should throw exception if host, database or user keys are missing
 			// should support no password if key is not provided
 			$dsn = 'host=' . $this->settings['database']['host'] . ';dbname=' . $this->settings['database']['database'];
@@ -111,7 +111,7 @@ class Config {
 	 *
 	 */
 	public function web_ui_settings(): array {
-		if(FALSE != $this->settings && array_key_exists('oauth', $this->settings)) {
+		if (false != $this->settings && array_key_exists('oauth', $this->settings)) {
 			return $this->settings['oauth'];
 		}
 

--- a/src/Entity/APIKey.php
+++ b/src/Entity/APIKey.php
@@ -18,7 +18,7 @@ class APIKey {
 	 * The token that can be presented to authenticate to the API in the
 	 * absence of a User Session
 	 */
-	protected ?string $token = NULL;
+	protected ?string $token = null;
 
 	/**
 	 * Get the name of this API key
@@ -33,7 +33,7 @@ class APIKey {
 	 * @throws InvalidArgumentException if the name is the empty string
 	 */
 	public function set_name(string $name): self {
-		if($name === '') {
+		if ($name === '') {
 			throw new InvalidArgumentException('You must specify the API key\'s name');
 		}
 
@@ -46,7 +46,7 @@ class APIKey {
 	 * absence of a Session
 	 */
 	public function token(): string {
-		if(NULL === $this->token) {
+		if (null === $this->token) {
 			$this->token = $this->create_token();
 		}
 		return $this->token;
@@ -63,7 +63,7 @@ class APIKey {
 
 	private function create_token(): string {
 		// If libsodium is available use it :)
-		if(true === function_exists('random_bytes')) {
+		if (true === function_exists('random_bytes')) {
 			return bin2hex(random_bytes(16));
 		} else {
 			return sprintf('%04X%04X%04X%04X%04X%04X%04X%04X', mt_rand(0, 65535), mt_rand(0, 65535), mt_rand(0, 65535), mt_rand(0, 65535), mt_rand(0, 65535), mt_rand(0, 65535), mt_rand(0, 65535), mt_rand(0, 65535));

--- a/src/Entity/CardType.php
+++ b/src/Entity/CardType.php
@@ -39,7 +39,7 @@ class CardType {
 
 	/** Set the card type's human readable name */
 	private function set_name(string $name): self {
-		if(0 < strlen($name)) {
+		if (0 < strlen($name)) {
 			$this->name = $name;
 			return $this;
 		}
@@ -65,7 +65,7 @@ class CardType {
 	 */
 	public static function is_valid(int $type): bool {
 		$valid_values = array_values((new ReflectionClass(get_class()))->getConstants());
-		if(in_array($type, $valid_values)) {
+		if (in_array($type, $valid_values)) {
 			return true;
 		}
 
@@ -79,7 +79,7 @@ class CardType {
 	 * @return string  the name for the card type
 	 */
 	public static function name_for_type(int $type_id): string {
-		switch($type_id) {
+		switch ($type_id) {
 			case self::SHUTDOWN:
 				return 'Shutdown Card';
 			case self::PROXY:

--- a/src/Entity/Charge.php
+++ b/src/Entity/Charge.php
@@ -13,13 +13,13 @@ class Charge {
 	protected int $user_id = -1;
 
 	/** The the user who was charged */
-	protected ?User $user = NULL;
+	protected ?User $user = null;
 
 	/** The id of the equipment the user used */
 	protected int $equipment_id = -1;
 
 	/** The the equipment the user used */
-	protected ?Equipment $equipment = NULL;
+	protected ?Equipment $equipment = null;
 
 	/** The time of this charge */
 	protected string $time = '';
@@ -55,7 +55,7 @@ class Charge {
 	/** Get the charged user's name */
 	public function user_name(): string {
 		$user = $this->user();
-		if ($user === NULL) {
+		if ($user === null) {
 			return '';
 		}
 
@@ -88,7 +88,7 @@ class Charge {
 	/** Get the name of the equipment the user used to incur the Charge */
 	public function equipment_name(): string {
 		$equipment = $this->equipment();
-		if ($equipment === NULL) {
+		if ($equipment === null) {
 			return '';
 		}
 

--- a/src/Entity/ChargePolicy.php
+++ b/src/Entity/ChargePolicy.php
@@ -46,7 +46,7 @@ class ChargePolicy {
 			self::PER_USE,
 			self::PER_MINUTE
 		];
-		if(in_array($policy_id, $valid_values)) {
+		if (in_array($policy_id, $valid_values)) {
 			return true;
 		}
 
@@ -60,12 +60,17 @@ class ChargePolicy {
 	 * @return string - name for the charge policy
 	 */
 	public static function name_for_policy(int $policy_id): string {
-		switch($policy_id) {
-			case self::MANUALLY_ADJUSTED: return 'Manually Adjusted';
-			case self::NO_CHARGE: return 'No Charge';
-			case self::PER_USE: return 'Per Use';
-			case self::PER_MINUTE: return 'Per Minute';
-			default: return 'Invalid';
+		switch ($policy_id) {
+			case self::MANUALLY_ADJUSTED:
+				return 'Manually Adjusted';
+			case self::NO_CHARGE:
+				return 'No Charge';
+			case self::PER_USE:
+				return 'Per Use';
+			case self::PER_MINUTE:
+				return 'Per Minute';
+			default:
+				return 'Invalid';
 		}
 	}
 }

--- a/src/Entity/Equipment.php
+++ b/src/Entity/Equipment.php
@@ -17,16 +17,16 @@ class Equipment {
 	protected int $type_id = -1;
 
 	/** This equipment's type */
-	protected ?EquipmentType $type = NULL;
+	protected ?EquipmentType $type = null;
 
 	/** The MAC address of the portalbox the equipment is connected to */
-	protected ?string $mac_address = NULL;
+	protected ?string $mac_address = null;
 
 	/** The id for the location where the equipment is located */
 	protected int $location_id = -1;
 
 	/** The location where the equipment is located */
-	protected ?Location $location = NULL;
+	protected ?Location $location = null;
 
 	/**
 	 * The default maximum duration of an activation session for this
@@ -44,7 +44,7 @@ class Equipment {
 	protected int $service_minutes = 0;
 
 	/** The ip Address of the box */
-	protected ?string $ip_address = NULL;
+	protected ?string $ip_address = null;
 
 	/** Get the name of this equipment */
 	public function name(): string {
@@ -57,7 +57,7 @@ class Equipment {
 	 * @throws InvalidArgumentException  if the parameter is the empty string
 	 */
 	public function set_name(string $name): self {
-		if($name === '') {
+		if ($name === '') {
 			throw new InvalidArgumentException('You must specify the equipment\'s name');
 		}
 
@@ -73,7 +73,7 @@ class Equipment {
 	/** Set the equipment's type id */
 	public function set_type_id(int $type_id): self {
 		$this->type_id = $type_id;
-		$this->type = NULL;
+		$this->type = null;
 		return $this;
 	}
 
@@ -101,12 +101,12 @@ class Equipment {
 	 *     address.
 	 */
 	public function set_mac_address(?string $mac_address): self {
-		if(is_null($mac_address)) {
-			$this->mac_address = NULL;
+		if (is_null($mac_address)) {
+			$this->mac_address = null;
 			return $this;
 		}
 
-		if(!preg_match('/^([0-9A-Fa-f]{2}[:-]?){5}([0-9A-Fa-f]{2})$/', $mac_address)) {
+		if (!preg_match('/^([0-9A-Fa-f]{2}[:-]?){5}([0-9A-Fa-f]{2})$/', $mac_address)) {
 			throw new InvalidArgumentException('The specified MAC Address must be valid');
 		}
 
@@ -122,7 +122,7 @@ class Equipment {
 	/** Set the equipment's location id */
 	public function set_location_id(int $location_id): self {
 		$this->location_id = $location_id;
-		$this->location = NULL;
+		$this->location = null;
 		return $this;
 	}
 
@@ -192,5 +192,4 @@ class Equipment {
 		$this->ip_address = $ip_address;
 		return $this;
 	}
-
 }

--- a/src/Entity/EquipmentType.php
+++ b/src/Entity/EquipmentType.php
@@ -17,7 +17,7 @@ class EquipmentType {
 	protected bool $requires_training = true;
 
 	/** The rate to charge */
-	protected ?string $charge_rate = NULL;
+	protected ?string $charge_rate = null;
 
 	/** The id of the Charge policy for this equipment type */
 	protected int $charge_policy_id = ChargePolicy::MANUALLY_ADJUSTED;
@@ -32,7 +32,7 @@ class EquipmentType {
 
 	/** Set the name of this equipment type */
 	public function set_name(string $name): self {
-		if($name === '') {
+		if ($name === '') {
 			throw new InvalidArgumentException('You must specify the equipment type\'s name');
 		}
 
@@ -58,7 +58,7 @@ class EquipmentType {
 
 	/** Set the charge rate of this equipment type */
 	public function set_charge_rate(?string $charge_rate): self {
-		if(NULL === $charge_rate || $charge_rate !== '') {
+		if (null === $charge_rate || $charge_rate !== '') {
 			$this->charge_rate = $charge_rate;
 			return $this;
 		}
@@ -85,7 +85,7 @@ class EquipmentType {
 	 *             public constants from ChargePolicy
 	 */
 	public function set_charge_policy_id(int $charge_policy_id): self {
-		if(ChargePolicy::is_valid($charge_policy_id)) {
+		if (ChargePolicy::is_valid($charge_policy_id)) {
 			$this->charge_policy_id = $charge_policy_id;
 			return $this;
 		}

--- a/src/Entity/Location.php
+++ b/src/Entity/Location.php
@@ -28,7 +28,7 @@ class Location {
 	 * @throws InvalidArgumentException if the name is the empty string
 	 */
 	public function set_name(string $name): self {
-		if($name === '') {
+		if ($name === '') {
 			throw new InvalidArgumentException('You must specify the location\'s name');
 		}
 

--- a/src/Entity/LoggedEvent.php
+++ b/src/Entity/LoggedEvent.php
@@ -18,19 +18,19 @@ class LoggedEvent {
 	protected int $card_id = -1;
 
 	/** The card which triggered this event */
-	protected ?Card $card = NULL;
+	protected ?Card $card = null;
 
 	/** The id of the user whose card which triggered this event */
 	protected int $user_id = -1;
 
 	/** The user whose card which triggered this event */
-	protected ?User $user = NULL;
+	protected ?User $user = null;
 
 	/** The id of the equipment which reported this event */
 	protected int $equipment_id = -1;
 
 	/** The name of the equipment which reported this event */
-	protected ?Equipment $equipment = NULL;
+	protected ?Equipment $equipment = null;
 
 	/** The id of the equipment type for this event */
 	private int $equipment_type_id = -1;
@@ -74,14 +74,14 @@ class LoggedEvent {
 	/** Set the id of the equipment which reported this event */
 	public function set_equipment_id(int $equipment_id): self {
 		$this->equipment_id = $equipment_id;
-		$this->equipment = NULL;
+		$this->equipment = null;
 		return $this;
 	}
 
 	// a convenience method... see Model\Entity\LoggedEventModel ;)
 	/** Get the name of the equipment which reported this event */
 	public function equipment_name(): ?string {
-		if(NULL === $this->equipment) {
+		if (null === $this->equipment) {
 			return '';
 		}
 
@@ -96,7 +96,7 @@ class LoggedEvent {
 	/** Set the equipment which reported this event */
 	public function set_equipment(?Equipment $equipment): self {
 		$this->equipment = $equipment;
-		if(NULL === $equipment) {
+		if (null === $equipment) {
 			$this->equipment_id = -1;
 		} else {
 			$this->equipment_id = $equipment->id();
@@ -113,7 +113,7 @@ class LoggedEvent {
 	/** Set the id of the card which triggered this event */
 	public function set_card_id(int $card_id): self {
 		$this->card_id = $card_id;
-		$this->card = NULL;
+		$this->card = null;
 		return $this;
 	}
 
@@ -125,7 +125,7 @@ class LoggedEvent {
 	/** Set the card which triggered this event */
 	public function set_card(?Card $card): self {
 		$this->card = $card;
-		if(NULL === $card) {
+		if (null === $card) {
 			$this->card_id = -1;
 		} else {
 			$this->card_id = $card->id();
@@ -142,14 +142,14 @@ class LoggedEvent {
 	/** Set the id of the user whose card which triggered this event */
 	public function set_user_id(int $user_id): self {
 		$this->user_id = $user_id;
-		$this->user = NULL;
+		$this->user = null;
 		return $this;
 	}
 
 	// a convenience method... see Model\Entity\LoggedEventModel ;)
 	/** Get the name of the user whose action triggered this event */
 	public function user_name(): string {
-		if(NULL === $this->user) {
+		if (null === $this->user) {
 			return '';
 		}
 
@@ -164,7 +164,7 @@ class LoggedEvent {
 	/** Set the user whose card which triggered this event */
 	public function set_user(?User $user): self {
 		$this->user = $user;
-		if(NULL === $user) {
+		if (null === $user) {
 			$this->user_id = -1;
 		} else {
 			$this->user_id = $user->id();
@@ -179,7 +179,7 @@ class LoggedEvent {
 	 * event is located
 	 */
 	public function location_name(): ?string {
-		if(NULL === $this->equipment) {
+		if (null === $this->equipment) {
 			return '';
 		}
 

--- a/src/Entity/LoggedEventType.php
+++ b/src/Entity/LoggedEventType.php
@@ -51,7 +51,7 @@ class LoggedEventType {
 			self::STARTUP_COMPLETE,
 			self::PLANNED_SHUTDOWN
 		];
-		if(in_array($type, $valid_values)) {
+		if (in_array($type, $valid_values)) {
 			return true;
 		}
 
@@ -65,13 +65,19 @@ class LoggedEventType {
 	 * @return string - name for the event type
 	 */
 	public static function name_for_type(int $type_id): string {
-		switch($type_id) {
-			case self::UNSUCCESSFUL_AUTHENTICATION: return 'Failed Authentication';
-			case self::SUCCESSFUL_AUTHENTICATION: return 'Activation Session Begun';
-			case self::DEAUTHENTICATION: return 'Activation Session Ended';
-			case self::STARTUP_COMPLETE: return 'Startup Complete';
-			case self::PLANNED_SHUTDOWN: return 'Planned Shutdown';
-			default: return 'Invalid';
+		switch ($type_id) {
+			case self::UNSUCCESSFUL_AUTHENTICATION:
+				return 'Failed Authentication';
+			case self::SUCCESSFUL_AUTHENTICATION:
+				return 'Activation Session Begun';
+			case self::DEAUTHENTICATION:
+				return 'Activation Session Ended';
+			case self::STARTUP_COMPLETE:
+				return 'Startup Complete';
+			case self::PLANNED_SHUTDOWN:
+				return 'Planned Shutdown';
+			default:
+				return 'Invalid';
 		}
 	}
 }

--- a/src/Entity/Permission.php
+++ b/src/Entity/Permission.php
@@ -368,7 +368,7 @@ class Permission {
 			self::LIST_USERS,
 			self::READ_OWN_USER,
 		];
-		if(in_array($permission, $valid_values)) {
+		if (in_array($permission, $valid_values)) {
 			return true;
 		}
 

--- a/src/Entity/Role.php
+++ b/src/Entity/Role.php
@@ -27,7 +27,7 @@ class Role {
 	 *
 	 * @var int[]|null
 	 */
-	protected ?array $permissions = NULL;
+	protected ?array $permissions = null;
 
 	/** Get the name of this role */
 	public function name(): string {
@@ -68,7 +68,7 @@ class Role {
 	 * @return int[]  the list of the role's permissions
 	 */
 	public function permissions(): array {
-		if(NULL === $this->permissions) {
+		if (null === $this->permissions) {
 			return array();
 		}
 		return $this->permissions;
@@ -82,8 +82,8 @@ class Role {
 	 *             not not one of the public constants from Permission
 	 */
 	public function set_permissions(array $permissions): self {
-		foreach($permissions as $permission) {
-			if(!Permission::is_valid($permission)) {
+		foreach ($permissions as $permission) {
+			if (!Permission::is_valid($permission)) {
 				throw new InvalidArgumentException('permission must be one of the public constants from Permission');
 			}
 		}
@@ -94,11 +94,10 @@ class Role {
 
 	/** Determine whether the role has a permission */
 	public function has_permission(int $permission): bool {
-		if(is_array($this->permissions)) {
+		if (is_array($this->permissions)) {
 			return in_array($permission, $this->permissions);
 		} else {
-			return FALSE;
+			return false;
 		}
 	}
-
 }

--- a/src/Entity/TrainingCard.php
+++ b/src/Entity/TrainingCard.php
@@ -7,7 +7,6 @@ namespace Portalbox\Entity;
  * portalbox shuts down when presented with cards of this type.
  */
 class TrainingCard extends Card {
-
 	/**
 	 * The id of the type of equipment this card can activate for training
 	 *
@@ -50,7 +49,7 @@ class TrainingCard extends Card {
 	 */
 	public function set_equipment_type_id(int $equipment_type_id): self {
 		$this->equipment_type_id = $equipment_type_id;
-		$this->equipment_type = NULL;
+		$this->equipment_type = null;
 		return $this;
 	}
 
@@ -64,7 +63,7 @@ class TrainingCard extends Card {
 		return $this->equipment_type;
 	}
 
-	public function set_equipment_type(?EquipmentType $equipment_type): self{
+	public function set_equipment_type(?EquipmentType $equipment_type): self {
 		$this->equipment_type = $equipment_type;
 		return $this;
 	}
@@ -78,7 +77,7 @@ class TrainingCard extends Card {
 	 */
 	public function set_type(?EquipmentType $equipment_type): self {
 		$this->equipment_type = $equipment_type;
-		if(NULL === $equipment_type) {
+		if (null === $equipment_type) {
 			$this->equipment_type_id = -1;
 		} else {
 			$this->equipment_type_id = $equipment_type->id();

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -78,13 +78,13 @@ class User {
 	/** Set the user's role id */
 	public function set_role_id(int $role_id): self {
 		$this->role_id = $role_id;
-		$this->role = NULL;
+		$this->role = null;
 		return $this;
 	}
 
 	/** Get the user's role's name */
 	public function role_name(): string {
-		if(NULL === $this->role) {
+		if (null === $this->role) {
 			return '';
 		} else {
 			return $this->role->name();
@@ -99,7 +99,7 @@ class User {
 	/** Set the user's role */
 	public function set_role(?Role $role): self {
 		$this->role = $role;
-		if(NULL === $role) {
+		if (null === $role) {
 			$this->role_id = -1;
 		} else {
 			$this->role_id = $role->id();
@@ -121,7 +121,7 @@ class User {
 
 	/** Get the authorizations for this user */
 	public function authorizations(): array {
-		if(NULL === $this->authorizations) {
+		if (null === $this->authorizations) {
 			return array();
 		}
 		return $this->authorizations;

--- a/src/Entity/UserCard.php
+++ b/src/Entity/UserCard.php
@@ -43,7 +43,7 @@ class UserCard extends Card {
 	 */
 	public function set_user_id(?int $user_id): self {
 		$this->user_id = $user_id;
-		$this->user = NULL; //Create new user from user_id
+		$this->user = null; //Create new user from user_id
 		return $this;
 	}
 
@@ -64,7 +64,7 @@ class UserCard extends Card {
 	 */
 	public function set_user(?User $user): self {
 		$this->user = $user;
-		if(NULL === $user) {
+		if (null === $user) {
 			$this->user_id = -1;
 		} else {
 			$this->user_id = $user->id();

--- a/src/Model/APIKeyModel.php
+++ b/src/Model/APIKeyModel.php
@@ -5,7 +5,6 @@ namespace Portalbox\Model;
 use Portalbox\Entity\APIKey;
 use Portalbox\Exception\DatabaseException;
 use Portalbox\Query\APIKeyQuery;
-
 use PDO;
 
 /**
@@ -27,7 +26,7 @@ class APIKeyModel extends AbstractModel {
 		$statement->bindValue(':name', $key->name());
 		$statement->bindValue(':token', $key->token());
 
-		if($statement->execute()) {
+		if ($statement->execute()) {
 			return $key->set_id($connection->lastInsertId('api_keys_id_seq'));
 		} else {
 			throw new DatabaseException($connection->errorInfo()[2]);
@@ -46,8 +45,8 @@ class APIKeyModel extends AbstractModel {
 		$sql = 'SELECT id, name, token FROM api_keys WHERE id = :id';
 		$statement = $connection->prepare($sql);
 		$statement->bindValue(':id', $id, PDO::PARAM_INT);
-		if($statement->execute()) {
-			if($data = $statement->fetch(PDO::FETCH_ASSOC)) {
+		if ($statement->execute()) {
+			if ($data = $statement->fetch(PDO::FETCH_ASSOC)) {
 				return $this->buildAPIKeyFromArray($data);
 			} else {
 				return null;
@@ -73,13 +72,13 @@ class APIKeyModel extends AbstractModel {
 		$statement->bindValue(':name', $key->name());
 		// this is weird... we don't update the token because it is immutable
 
-		if($statement->execute()) {
+		if ($statement->execute()) {
 			// fill in readonly fields...
 			$sql = 'SELECT token FROM api_keys WHERE id = :id';
 			$query = $connection->prepare($sql);
 			$query->bindValue(':id', $key->id(), PDO::PARAM_INT);
-			if($query->execute()) {
-				if($data = $query->fetch(PDO::FETCH_ASSOC)) {
+			if ($query->execute()) {
+				if ($data = $query->fetch(PDO::FETCH_ASSOC)) {
 					$key->set_token($data['token']);
 				} else {
 					return null;
@@ -104,12 +103,12 @@ class APIKeyModel extends AbstractModel {
 	public function delete(int $id): ?APIKey {
 		$key = $this->read($id);
 
-		if(NULL !== $key) {
+		if (null !== $key) {
 			$connection = $this->configuration()->writable_db_connection();
 			$sql = 'DELETE FROM api_keys WHERE id = :id';
 			$statement = $connection->prepare($sql);
 			$statement->bindValue(':id', $id, PDO::PARAM_INT);
-			if(!$statement->execute()) {
+			if (!$statement->execute()) {
 				throw new DatabaseException($connection->errorInfo()[2]);
 			}
 		}
@@ -125,31 +124,31 @@ class APIKeyModel extends AbstractModel {
 	 * @return APIKey[]|null - a list of api keys which match the search query
 	 */
 	public function search(APIKeyQuery $query): ?array {
-		if(NULL === $query) {
+		if (null === $query) {
 			// no query... bail
-			return NULL;
+			return null;
 		}
 
 		$connection = $this->configuration()->readonly_db_connection();
 		$sql = 'SELECT id, name, token FROM api_keys';
 
 		$where_clause_fragments = array();
-		if(NULL !== $query->token()) {
+		if (null !== $query->token()) {
 			$where_clause_fragments[] = 'token = :token';
 		}
-		if(0 < count($where_clause_fragments)) {
+		if (0 < count($where_clause_fragments)) {
 			$sql .= ' WHERE ';
 			$sql .= join(' AND ', $where_clause_fragments);
 		}
 
 		$statement = $connection->prepare($sql);
-		if(NULL !== $query->token()) {
+		if (null !== $query->token()) {
 			$statement->bindValue(':token', $query->token());
 		}
 
-		if($statement->execute()) {
+		if ($statement->execute()) {
 			$data = $statement->fetchAll(PDO::FETCH_ASSOC);
-			if(FALSE !== $data) {
+			if (false !== $data) {
 				return $this->buildAPIKeysFromArrays($data);
 			} else {
 				return null;
@@ -169,7 +168,7 @@ class APIKeyModel extends AbstractModel {
 	private function buildAPIKeysFromArrays(array $data): array {
 		$keys = array();
 
-		foreach($data as $datum) {
+		foreach ($data as $datum) {
 			$keys[] = $this->buildAPIKeyFromArray($datum);
 		}
 

--- a/src/Model/CardTypeModel.php
+++ b/src/Model/CardTypeModel.php
@@ -4,38 +4,37 @@ namespace Portalbox\Model;
 
 use Portalbox\Entity\CardType;
 use Portalbox\Exception\DatabaseException;
-
 use PDO;
 
 class CardTypeModel extends AbstractModel {
-    public function search(): ?array {
-        $connection = $this->configuration()->readonly_db_connection();
-        $sql = 'SELECT id, name FROM card_types';
-        $statement = $connection->prepare($sql);
-        if($statement->execute()) {
-            $data = $statement->fetchAll(PDO::FETCH_ASSOC);
-            if(FALSE !== $data) {
-                return $this->buildCardTypesFromArrays($data);
-            } else {
-                return null;
-            }
-        } else {
-            throw new DatabaseExcpetion($connection->errorInfo()[2]);
-        }
-    }
+	public function search(): ?array {
+		$connection = $this->configuration()->readonly_db_connection();
+		$sql = 'SELECT id, name FROM card_types';
+		$statement = $connection->prepare($sql);
+		if ($statement->execute()) {
+			$data = $statement->fetchAll(PDO::FETCH_ASSOC);
+			if (false !== $data) {
+				return $this->buildCardTypesFromArrays($data);
+			} else {
+				return null;
+			}
+		} else {
+			throw new DatabaseExcpetion($connection->errorInfo()[2]);
+		}
+	}
 
-    private function buildCardTypesFromArray(array $data): CardType {
-        return (new CardType())
-            ->set_id($data['id']);
-    }
+	private function buildCardTypesFromArray(array $data): CardType {
+		return (new CardType())
+			->set_id($data['id']);
+	}
 
-    private function buildCardTypesFromArrays(array $data): array {
-        $card_types = array();
+	private function buildCardTypesFromArrays(array $data): array {
+		$card_types = array();
 
-        foreach($data as $datum) {
-            $card_types[] = $this->buildCardTypesFromArray($datum);
-        }
+		foreach ($data as $datum) {
+			$card_types[] = $this->buildCardTypesFromArray($datum);
+		}
 
-        return $card_types;
-    }
+		return $card_types;
+	}
 }

--- a/src/Model/ChargeModel.php
+++ b/src/Model/ChargeModel.php
@@ -7,10 +7,8 @@ use Portalbox\Exception\DatabaseException;
 use Portalbox\Query\ChargeQuery;
 use Portalbox\Query\EquipmentQuery;
 use Portalbox\Query\UserQuery;
-
 use Portalbox\Model\EquipmentModel;
 use Portalbox\Model\UserModel;
-
 use PDO;
 
 /**
@@ -37,7 +35,7 @@ class ChargeModel extends AbstractModel {
 		$query->bindValue(':charge_rate', $charge->charge_rate());
 		$query->bindValue(':charged_time', $charge->charged_time());
 
-		if($query->execute()) {
+		if ($query->execute()) {
 			return $charge->set_id($connection->lastInsertId('charges_id_seq'));
 		} else {
 			throw new DatabaseException($connection->errorInfo()[2]);
@@ -56,8 +54,8 @@ class ChargeModel extends AbstractModel {
 		$sql = 'SELECT c.id, c.user_id, u.name AS user_name, c.equipment_id, e.name AS equipment_name, c.time, c.amount, c.charge_policy_id, c.charge_rate, c.charged_time FROM charges AS c INNER JOIN equipment as e ON e.id = c.equipment_id INNER JOIN users AS u on u.id = c.user_id WHERE c.id = :id';
 		$query = $connection->prepare($sql);
 		$query->bindValue(':id', $id, PDO::PARAM_INT);
-		if($query->execute()) {
-			if($data = $query->fetch(PDO::FETCH_ASSOC)) {
+		if ($query->execute()) {
+			if ($data = $query->fetch(PDO::FETCH_ASSOC)) {
 				return $this->buildChargeFromArray($data);
 			} else {
 				return null;
@@ -88,7 +86,7 @@ class ChargeModel extends AbstractModel {
 		$query->bindValue(':charge_rate', $charge->charge_rate());
 		$query->bindValue(':charged_time', $charge->charged_time());
 
-		if($query->execute()) {
+		if ($query->execute()) {
 			return $charge;
 		} else {
 			throw new DatabaseException($connection->errorInfo()[2]);
@@ -105,12 +103,12 @@ class ChargeModel extends AbstractModel {
 	public function delete(int $id): ?Charge {
 		$charge = $this->read($id);
 
-		if(NULL !== $charge) {
+		if (null !== $charge) {
 			$connection = $this->configuration()->writable_db_connection();
 			$sql = 'DELETE FROM charges WHERE id = :id';
 			$query = $connection->prepare($sql);
 			$query->bindValue(':id', $id, PDO::PARAM_INT);
-			if(!$query->execute()) {
+			if (!$query->execute()) {
 				throw new DatabaseException($connection->errorInfo()[2]);
 			}
 		}
@@ -126,9 +124,9 @@ class ChargeModel extends AbstractModel {
 	 * @return Charge[]|null - a list of charges which match the search query
 	 */
 	public function search(ChargeQuery $query): ?array {
-		if(NULL === $query) {
+		if (null === $query) {
 			// no query... bail
-			return NULL;
+			return null;
 		}
 
 		$connection = $this->configuration()->readonly_db_connection();
@@ -144,24 +142,24 @@ class ChargeModel extends AbstractModel {
 		$where_clause_fragments = array();
 		$parameters = array();
 
-		if(NULL !== $query->equipment_id()) {
+		if (null !== $query->equipment_id()) {
 			$where_clause_fragments[] = 'c.equipment_id = :equipment_id';
 			$parameters[':equipment_id'] = $query->equipment_id();
 		}
-		if(NULL !== $query->user_id()) {
+		if (null !== $query->user_id()) {
 			$where_clause_fragments[] = 'c.user_id = :user_id';
 			$parameters[':user_id'] = $query->user_id();
 		}
 
-		if(NULL !== $query->on_or_after()) {
+		if (null !== $query->on_or_after()) {
 			$where_clause_fragments[] = 'c.time >= :after';
 			$parameters[':after'] = $query->on_or_after();
 		}
-		if(NULL !== $query->on_or_before()) {
+		if (null !== $query->on_or_before()) {
 			$where_clause_fragments[] = 'c.time <= :before';
 			$parameters[':before'] = $query->on_or_before();
 		}
-		if(0 < count($where_clause_fragments)) {
+		if (0 < count($where_clause_fragments)) {
 			$sql .= ' WHERE ';
 			$sql .= join(' AND ', $where_clause_fragments);
 		}
@@ -169,24 +167,20 @@ class ChargeModel extends AbstractModel {
 
 		$statement = $connection->prepare($sql);
 		// run search
-		foreach($parameters as $k => $v) {
+		foreach ($parameters as $k => $v) {
 			$statement->bindValue($k, $v);
 		}
 
 
-		if($statement->execute()) {
+		if ($statement->execute()) {
 			$data = $statement->fetchAll(PDO::FETCH_ASSOC);
 
-			if(FALSE !== $data) {
-
+			if (false !== $data) {
 				return $this->buildChargesFromArrays($data);
-
 			} else {
-
 				return null;
 			}
 		} else {
-
 			throw new DatabaseException($connection->errorInfo()[2]);
 		}
 	}
@@ -215,37 +209,41 @@ class ChargeModel extends AbstractModel {
 		$e_query = new EquipmentQuery();
 		$e_query->set_include_out_of_service(true);
 		$u_query = new UserQuery();
-		$u_query->set_include_inactive(TRUE);
+		$u_query->set_include_inactive(true);
 
 		$machines = $e_model->search($e_query);
 		$users = $u_model->search($u_query);
 
-		foreach($data as $datum) {
+		foreach ($data as $datum) {
 			$charges[] = $this->buildChargeFromArray($datum);
 			// echo print_r($datum, true) . "<br>";
 		}
 		// echo count($charges). "<br>";
 		// $x = 0;
-		foreach($charges as $charge) {
+		foreach ($charges as $charge) {
 			// echo $x . ":";
 			// echo $charge->equipment_id() . "<br>";
 			// $x += 1;
 			$e_id = $charge->equipment_id();
 
-			$machine = array_filter($machines,
+			$machine = array_filter(
+				$machines,
 				function ($e) use ($e_id) {
 					return $e->id() == $e_id;
-				});
+				}
+			);
 
 			// echo array_pop($machine)->id();
 			$charge->set_equipment(array_pop($machine));
 
 			$u_id = $charge->user_id();
 
-			$user = array_filter($users,
+			$user = array_filter(
+				$users,
 				function ($e) use ($u_id) {
 					return $e->id() == $u_id;
-				});
+				}
+			);
 
 			$charge->set_user(array_pop($user));
 		}

--- a/src/Model/Entity/Charge.php
+++ b/src/Model/Entity/Charge.php
@@ -3,11 +3,9 @@
 namespace Portalbox\Model\Entity;
 
 use Portalbox\Config;
-
 use Portalbox\Entity\Charge as AbstractCharge;
 use Portalbox\Entity\Equipment;
 use Portalbox\Entity\User;
-
 use Portalbox\Model\EquipmentModel;
 use Portalbox\Model\UserModel;
 
@@ -84,7 +82,7 @@ class Charge extends AbstractCharge {
 	 * @return Equipment|null - the equipment the user used to incur the Charge
 	 */
 	public function equipment(): ?Equipment {
-		if(NULL === $this->equipment) {
+		if (null === $this->equipment) {
 			$this->equipment = (new EquipmentModel($this->configuration()))->read($this->equipment_id());
 		}
 
@@ -116,7 +114,7 @@ class Charge extends AbstractCharge {
 	 * @return User|null - the charged user
 	 */
 	public function user(): ?User {
-		if(NULL === $this->user) {
+		if (null === $this->user) {
 			$this->user = (new UserModel($this->configuration()))->read($this->user_id());
 		}
 

--- a/src/Model/Entity/Equipment.php
+++ b/src/Model/Entity/Equipment.php
@@ -48,7 +48,7 @@ class Equipment extends AbstractEquipment {
 	 * @return EquipmentType|null - the equipment's type
 	 */
 	public function type(): ?EquipmentType {
-		if(NULL === $this->type) {
+		if (null === $this->type) {
 			$this->type = (new EquipmentTypeModel($this->configuration()))->read($this->type_id());
 		}
 
@@ -61,7 +61,7 @@ class Equipment extends AbstractEquipment {
 	 * @return Location|null - the equipment's location
 	 */
 	public function location(): ?Location {
-		if(NULL === $this->location) {
+		if (null === $this->location) {
 			$this->location = (new LocationModel($this->configuration()))->read($this->location_id());
 		}
 

--- a/src/Model/Entity/LoggedEvent.php
+++ b/src/Model/Entity/LoggedEvent.php
@@ -3,7 +3,6 @@
 namespace Portalbox\Model\Entity;
 
 use Portalbox\Config;
-
 use Portalbox\Entity\CardType;
 use Portalbox\Entity\LoggedEvent as AbstractLoggedEvent;
 
@@ -16,22 +15,22 @@ class LoggedEvent extends AbstractLoggedEvent {
 	/**
 	 * The id of this event's card's type
 	 */
-	private ?int $card_type_id = NULL;
+	private ?int $card_type_id = null;
 
 	/**
 	 * The name of this event's equipment's name
 	 */
-	private ?string $equipment_name = NULL;
+	private ?string $equipment_name = null;
 
 	/**
 	 * The name of this event's equipment's location's name
 	 */
-	private ?string $location_name = NULL;
+	private ?string $location_name = null;
 
 	/**
 	 * The name of this event's user's name
 	 */
-	private ?string $user_name = NULL;
+	private ?string $user_name = null;
 
 	/**
 	 * @param Config configuration - the configuration to use
@@ -103,7 +102,7 @@ class LoggedEvent extends AbstractLoggedEvent {
 	 * Get this event's user's name
 	 */
 	public function user_name(): string {
-		if(CardType::TRAINING == $this->card_type_id) {
+		if (CardType::TRAINING == $this->card_type_id) {
 			return 'Trainer';
 		}
 

--- a/src/Model/Entity/User.php
+++ b/src/Model/Entity/User.php
@@ -72,7 +72,7 @@ class User extends AbstractUser {
 	 * @return Role|null - the user's role
 	 */
 	public function role(): ?Role {
-		if(NULL === $this->role) {
+		if (null === $this->role) {
 			$this->role = (new RoleModel($this->configuration()))->read($this->role_id());
 		}
 

--- a/src/Model/EquipmentModel.php
+++ b/src/Model/EquipmentModel.php
@@ -6,14 +6,12 @@ use Portalbox\Entity\Equipment;
 use Portalbox\Exception\DatabaseException;
 use Portalbox\Model\Entity\Equipment as PDOAwareEquipment;
 use Portalbox\Query\EquipmentQuery;
-
 use PDO;
 
 /**
  * EquipmentModel is our bridge between the database and higher level Entities.
  */
 class EquipmentModel extends AbstractModel {
-
 	/**
 	 * Save a newly created Equipment to the database
 	 *
@@ -34,7 +32,7 @@ class EquipmentModel extends AbstractModel {
 		$query->bindValue(':in_service', $equipment->is_in_service(), PDO::PARAM_BOOL);
 		$query->bindValue(':service_minutes', $equipment->service_minutes(), PDO::PARAM_INT);
 
-		if($query->execute()) {
+		if ($query->execute()) {
 			return $equipment
 					->set_id($connection->lastInsertId('equipment_id_seq'))
 					->set_is_in_use(false);
@@ -56,12 +54,9 @@ class EquipmentModel extends AbstractModel {
 		$sql = 'SELECT e.id, e.name, e.type_id, e.mac_address, e.location_id, e.timeout, e.in_service, iu.equipment_id IS NOT NULL AS in_use, e.service_minutes, e.ip_address FROM equipment AS e LEFT JOIN in_use AS iu ON e.id = iu.equipment_id WHERE e.id = :id';
 		$query = $connection->prepare($sql);
 		$query->bindValue(':id', $id, PDO::PARAM_INT);
-		if($query->execute()) {
-
-			if($data = $query->fetch(PDO::FETCH_ASSOC)) {
-
+		if ($query->execute()) {
+			if ($data = $query->fetch(PDO::FETCH_ASSOC)) {
 				return $this->buildEquipmentFromArray($data);
-
 			} else {
 				return null;
 			}
@@ -92,7 +87,7 @@ class EquipmentModel extends AbstractModel {
 		$query->bindValue(':in_service', $equipment->is_in_service(), PDO::PARAM_BOOL);
 		$query->bindValue(':service_minutes', $equipment->service_minutes(), PDO::PARAM_INT);
 
-		if($query->execute()) {
+		if ($query->execute()) {
 			$equipment = (new PDOAwareEquipment($this->configuration()))
 				->set_id($equipment->id())
 				->set_name($equipment->name())
@@ -107,8 +102,8 @@ class EquipmentModel extends AbstractModel {
 			$sql = 'SELECT iu.equipment_id IS NOT NULL AS in_use, e.service_minutes FROM equipment AS e LEFT JOIN in_use AS iu ON e.id = iu.equipment_id WHERE e.id = :id';
 			$query = $connection->prepare($sql);
 			$query->bindValue(':id', $equipment->id(), PDO::PARAM_INT);
-			if($query->execute()) {
-				if($data = $query->fetch(PDO::FETCH_ASSOC)) {
+			if ($query->execute()) {
+				if ($data = $query->fetch(PDO::FETCH_ASSOC)) {
 					$equipment
 						->set_is_in_use($data['in_use'])
 						->set_service_minutes($data['service_minutes']);
@@ -135,12 +130,12 @@ class EquipmentModel extends AbstractModel {
 	public function delete(int $id): ?Equipment {
 		$equipment = $this->read($id);
 
-		if(NULL !== $equipment) {
+		if (null !== $equipment) {
 			$connection = $this->configuration()->writable_db_connection();
 			$sql = 'DELETE FROM equipment WHERE id = :id';
 			$query = $connection->prepare($sql);
 			$query->bindValue(':id', $id, PDO::PARAM_INT);
-			if(!$query->execute()) {
+			if (!$query->execute()) {
 				throw new DatabaseException($connection->errorInfo()[2]);
 			}
 		}
@@ -156,9 +151,9 @@ class EquipmentModel extends AbstractModel {
 	 * @return Equipment[]|null - a list of equipment which match the search query
 	 */
 	public function search(EquipmentQuery $query): ?array {
-		if(NULL === $query) {
+		if (null === $query) {
 			// no query... bail
-			return NULL;
+			return null;
 		}
 
 		$connection = $this->configuration()->readonly_db_connection();
@@ -175,24 +170,24 @@ class EquipmentModel extends AbstractModel {
 
 		$where_clause_fragments = array();
 		$parameters = array();
-		if(NULL !== $query->location_id()) {
+		if (null !== $query->location_id()) {
 			$where_clause_fragments[] = 'l.id = :location';
 			$parameters[':location'] = $query->location_id();
-		} else if(NULL !== $query->location()) {
+		} else if (null !== $query->location()) {
 			$where_clause_fragments[] = 'l.name = :location';
 			$parameters[':location'] = $query->location();
 		}
-		if(NULL !== $query->type()) {
+		if (null !== $query->type()) {
 			$where_clause_fragments[] = 't.name = :type';
 			$parameters[':type'] = $query->type();
 		}
-		if($query->include_out_of_service()) {
+		if ($query->include_out_of_service()) {
 			// do nothing i.e. do not filter for in service only
 		} else {
 			$where_clause_fragments[] = 'e.in_service = 1';
 		}
 
-		if(0 < count($where_clause_fragments)) {
+		if (0 < count($where_clause_fragments)) {
 			$sql .= ' WHERE ';
 			$sql .= join(' AND ', $where_clause_fragments);
 		}
@@ -200,13 +195,13 @@ class EquipmentModel extends AbstractModel {
 
 		$statement = $connection->prepare($sql);
 		// run search
-		foreach($parameters as $k => $v) {
+		foreach ($parameters as $k => $v) {
 			$statement->bindValue($k, $v);
 		}
 
-		if($statement->execute()) {
+		if ($statement->execute()) {
 			$data = $statement->fetchAll(PDO::FETCH_ASSOC);
-			if(FALSE !== $data) {
+			if (false !== $data) {
 				return $this->buildEquipmentFromArrays($data);
 			} else {
 				return null;
@@ -233,7 +228,7 @@ class EquipmentModel extends AbstractModel {
 	private function buildEquipmentFromArrays(array $data): array {
 		$equipment = [];
 
-		foreach($data as $datum) {
+		foreach ($data as $datum) {
 			$equipment[] = $this->buildEquipmentFromArray($datum);
 		}
 

--- a/src/Model/EquipmentTypeModel.php
+++ b/src/Model/EquipmentTypeModel.php
@@ -4,7 +4,6 @@ namespace Portalbox\Model;
 
 use Portalbox\Entity\EquipmentType;
 use Portalbox\Exception\DatabaseException;
-
 use PDO;
 
 /**
@@ -29,7 +28,7 @@ class EquipmentTypeModel extends AbstractModel {
 		$query->bindValue(':charge_policy_id', $type->charge_policy_id(), PDO::PARAM_INT);
 		$query->bindValue(':allow_proxy', $type->allow_proxy(), PDO::PARAM_BOOL);
 
-		if($query->execute()) {
+		if ($query->execute()) {
 			return $type->set_id($connection->lastInsertId('equipment_types_id_seq'));
 		} else {
 			throw new DatabaseException($connection->errorInfo()[2]);
@@ -48,8 +47,8 @@ class EquipmentTypeModel extends AbstractModel {
 		$sql = 'SELECT id, name, requires_training, charge_rate, charge_policy_id, allow_proxy FROM equipment_types WHERE id = :id';
 		$query = $connection->prepare($sql);
 		$query->bindValue(':id', $id, PDO::PARAM_INT);
-		if($query->execute()) {
-			if($data = $query->fetch(PDO::FETCH_ASSOC)) {
+		if ($query->execute()) {
+			if ($data = $query->fetch(PDO::FETCH_ASSOC)) {
 				return $this->buildEquipmentTypeFromArray($data);
 			} else {
 				return null;
@@ -78,7 +77,7 @@ class EquipmentTypeModel extends AbstractModel {
 		$query->bindValue(':charge_policy_id', $type->charge_policy_id(), PDO::PARAM_INT);
 		$query->bindValue(':allow_proxy', $type->allow_proxy(), PDO::PARAM_BOOL);
 
-		if($query->execute()) {
+		if ($query->execute()) {
 			return $type;
 		} else {
 			throw new DatabaseException($connection->errorInfo()[2]);
@@ -95,12 +94,12 @@ class EquipmentTypeModel extends AbstractModel {
 	public function delete(int $id): ?EquipmentType {
 		$type = $this->read($id);
 
-		if(NULL !== $type) {
+		if (null !== $type) {
 			$connection = $this->configuration()->writable_db_connection();
 			$sql = 'DELETE FROM equipment_types WHERE id = :id';
 			$query = $connection->prepare($sql);
 			$query->bindValue(':id', $id, PDO::PARAM_INT);
-			if(!$query->execute()) {
+			if (!$query->execute()) {
 				throw new DatabaseException($connection->errorInfo()[2]);
 			}
 		}
@@ -119,9 +118,9 @@ class EquipmentTypeModel extends AbstractModel {
 		$connection = $this->configuration()->readonly_db_connection();
 		$sql = 'SELECT id, name, requires_training, charge_policy_id, charge_rate, allow_proxy FROM equipment_types ORDER BY name';
 		$statement = $connection->prepare($sql);
-		if($statement->execute()) {
+		if ($statement->execute()) {
 			$data = $statement->fetchAll(PDO::FETCH_ASSOC);
-			if(FALSE !== $data) {
+			if (false !== $data) {
 				return $this->buildEquipmentTypesFromArrays($data);
 			} else {
 				return null;
@@ -144,7 +143,7 @@ class EquipmentTypeModel extends AbstractModel {
 	private function buildEquipmentTypesFromArrays(array $data): array {
 		$locations = array();
 
-		foreach($data as $datum) {
+		foreach ($data as $datum) {
 			$locations[] = $this->buildEquipmentTypeFromArray($datum);
 		}
 

--- a/src/Model/LocationModel.php
+++ b/src/Model/LocationModel.php
@@ -4,7 +4,6 @@ namespace Portalbox\Model;
 
 use Portalbox\Entity\Location;
 use Portalbox\Exception\DatabaseException;
-
 use PDO;
 
 /**
@@ -25,7 +24,7 @@ class LocationModel extends AbstractModel {
 
 		$query->bindValue(':name', $location->name());
 
-		if($query->execute()) {
+		if ($query->execute()) {
 			return $location->set_id($connection->lastInsertId('locations_id_seq'));
 		} else {
 			throw new DatabaseException($connection->errorInfo()[2]);
@@ -44,8 +43,8 @@ class LocationModel extends AbstractModel {
 		$sql = 'SELECT id, name FROM locations WHERE id = :id';
 		$query = $connection->prepare($sql);
 		$query->bindValue(':id', $id, PDO::PARAM_INT);
-		if($query->execute()) {
-			if($data = $query->fetch(PDO::FETCH_ASSOC)) {
+		if ($query->execute()) {
+			if ($data = $query->fetch(PDO::FETCH_ASSOC)) {
 				return $this->buildLocationFromArray($data);
 			} else {
 				return null;
@@ -70,7 +69,7 @@ class LocationModel extends AbstractModel {
 		$query->bindValue(':id', $location->id(), PDO::PARAM_INT);
 		$query->bindValue(':name', $location->name());
 
-		if($query->execute()) {
+		if ($query->execute()) {
 			return $location;
 		} else {
 			throw new DatabaseException($connection->errorInfo()[2]);
@@ -87,12 +86,12 @@ class LocationModel extends AbstractModel {
 	public function delete(int $id): ?Location {
 		$location = $this->read($id);
 
-		if(NULL !== $location) {
+		if (null !== $location) {
 			$connection = $this->configuration()->writable_db_connection();
 			$sql = 'DELETE FROM locations WHERE id = :id';
 			$query = $connection->prepare($sql);
 			$query->bindValue(':id', $id, PDO::PARAM_INT);
-			if(!$query->execute()) {
+			if (!$query->execute()) {
 				throw new DatabaseException($connection->errorInfo()[2]);
 			}
 		}
@@ -112,9 +111,9 @@ class LocationModel extends AbstractModel {
 
 		$sql = 'SELECT id, name FROM locations';
 		$statement = $connection->prepare($sql);
-		if($statement->execute()) {
+		if ($statement->execute()) {
 			$data = $statement->fetchAll(PDO::FETCH_ASSOC);
-			if(FALSE !== $data) {
+			if (false !== $data) {
 				return $this->buildLocationsFromArrays($data);
 			} else {
 				return null;
@@ -133,7 +132,7 @@ class LocationModel extends AbstractModel {
 	private function buildLocationsFromArrays(array $data): array {
 		$locations = array();
 
-		foreach($data as $datum) {
+		foreach ($data as $datum) {
 			$locations[] = $this->buildLocationFromArray($datum);
 		}
 

--- a/src/Model/LoggedEventModel.php
+++ b/src/Model/LoggedEventModel.php
@@ -6,14 +6,12 @@ use Portalbox\Entity\LoggedEvent;
 use Portalbox\Model\Entity\LoggedEvent as PDOAwareLoggedEvent;
 use Portalbox\Query\LoggedEventQuery;
 use Portalbox\Exception\DatabaseException;
-
 use PDO;
 
 /**
  * LoggedEventModel is our bridge between the database and higher level Entities.
  */
 class LoggedEventModel extends AbstractModel {
-
 	/**
 	 * Read a logged event by its unique ID
 	 *
@@ -50,8 +48,8 @@ class LoggedEventModel extends AbstractModel {
 		EOQ;
 		$query = $connection->prepare($sql);
 		$query->bindValue(':id', $id, PDO::PARAM_INT);
-		if($query->execute()) {
-			if($data = $query->fetch(PDO::FETCH_ASSOC)) {
+		if ($query->execute()) {
+			if ($data = $query->fetch(PDO::FETCH_ASSOC)) {
 				return $this->buildLoggedEventFromArray($data);
 			} else {
 				return null;
@@ -69,9 +67,9 @@ class LoggedEventModel extends AbstractModel {
 	 * @return LoggedEvent[]|null - a list of logged events
 	 */
 	public function search(LoggedEventQuery $query): ?array {
-		if(NULL === $query) {
+		if (null === $query) {
 			// no query... bail
-			return NULL;
+			return null;
 		}
 
 		$connection = $this->configuration()->readonly_db_connection();
@@ -101,31 +99,31 @@ class LoggedEventModel extends AbstractModel {
 
 		$where_clause_fragments = array();
 		$parameters = array();
-		if($query->equipment_id()) {
+		if ($query->equipment_id()) {
 			$where_clause_fragments[] = 'el.equipment_id = :equipment_id';
 			$parameters[':equipment_id'] = $query->equipment_id();
 		}
-		if($query->equipment_type_id()) {
+		if ($query->equipment_type_id()) {
 			$where_clause_fragments[] = 'et.id = :equipment_type_id';
 			$parameters[':equipment_type_id'] = $query->equipment_type_id();
 		}
-		if($query->location_id()) {
+		if ($query->location_id()) {
 			$where_clause_fragments[] = 'e.location_id = :location_id';
 			$parameters[':location_id'] = $query->location_id();
 		}
-		if($query->type_id()) {
+		if ($query->type_id()) {
 			$where_clause_fragments[] = 'el.event_type_id = :event_type_id';
 			$parameters[':event_type_id'] = $query->type_id();
 		}
-		if($query->on_or_after()) {
+		if ($query->on_or_after()) {
 			$where_clause_fragments[] = 'el.time >= :after';
 			$parameters[':after'] = $query->on_or_after();
 		}
-		if($query->on_or_before()) {
+		if ($query->on_or_before()) {
 			$where_clause_fragments[] = 'el.time <= :before';
 			$parameters[':before'] = $query->on_or_before();
 		}
-		if(0 < count($where_clause_fragments)) {
+		if (0 < count($where_clause_fragments)) {
 			$sql .= ' WHERE ';
 			$sql .= join(' AND ', $where_clause_fragments);
 		}
@@ -133,13 +131,13 @@ class LoggedEventModel extends AbstractModel {
 
 		$statement = $connection->prepare($sql);
 		// run search
-		foreach($parameters as $k => $v) {
+		foreach ($parameters as $k => $v) {
 			$statement->bindValue($k, $v);
 		}
 
-		if($statement->execute()) {
+		if ($statement->execute()) {
 			$data = $statement->fetchAll(PDO::FETCH_ASSOC);
-			if(FALSE !== $data) {
+			if (false !== $data) {
 				return $this->buildLoggedEventsFromArray($data);
 			} else {
 				return null;
@@ -167,7 +165,7 @@ class LoggedEventModel extends AbstractModel {
 	private function buildLoggedEventsFromArray(array $data): array {
 		$log = array();
 
-		foreach($data as $datum) {
+		foreach ($data as $datum) {
 			$log[] = $this->buildLoggedEventFromArray($datum);
 		}
 

--- a/src/Model/PaymentModel.php
+++ b/src/Model/PaymentModel.php
@@ -5,7 +5,6 @@ namespace Portalbox\Model;
 use Portalbox\Entity\Payment;
 use Portalbox\Exception\DatabaseException;
 use Portalbox\Query\PaymentQuery;
-
 use PDO;
 
 /**
@@ -28,7 +27,7 @@ class PaymentModel extends AbstractModel {
 		$query->bindValue(':amount', $payment->amount());
 		$query->bindValue(':time', $payment->time());
 
-		if($query->execute()) {
+		if ($query->execute()) {
 			return $payment->set_id($connection->lastInsertId('payments_id_seq'));
 		} else {
 			throw new DatabaseException($connection->errorInfo()[2]);
@@ -47,8 +46,8 @@ class PaymentModel extends AbstractModel {
 		$sql = 'SELECT id, user_id, amount, time FROM payments WHERE id = :id';
 		$query = $connection->prepare($sql);
 		$query->bindValue(':id', $id, PDO::PARAM_INT);
-		if($query->execute()) {
-			if($data = $query->fetch(PDO::FETCH_ASSOC)) {
+		if ($query->execute()) {
+			if ($data = $query->fetch(PDO::FETCH_ASSOC)) {
 				return $this->buildPaymentFromArray($data);
 			} else {
 				return null;
@@ -75,7 +74,7 @@ class PaymentModel extends AbstractModel {
 		$query->bindValue(':amount', $payment->amount());
 		$query->bindValue(':time', $payment->time());
 
-		if($query->execute()) {
+		if ($query->execute()) {
 			return $payment;
 		} else {
 			throw new DatabaseException($connection->errorInfo()[2]);
@@ -92,12 +91,12 @@ class PaymentModel extends AbstractModel {
 	public function delete(int $id): ?Payment {
 		$payment = $this->read($id);
 
-		if(NULL !== $payment) {
+		if (null !== $payment) {
 			$connection = $this->configuration()->writable_db_connection();
 			$sql = 'DELETE FROM payments WHERE id = :id';
 			$query = $connection->prepare($sql);
 			$query->bindValue(':id', $id, PDO::PARAM_INT);
-			if(!$query->execute()) {
+			if (!$query->execute()) {
 				throw new DatabaseException($connection->errorInfo()[2]);
 			}
 		}
@@ -113,28 +112,28 @@ class PaymentModel extends AbstractModel {
 	 * @return Payment[]|null - a list of payments which match the search query
 	 */
 	public function search(PaymentQuery $query): ?array {
-		if(NULL === $query) {
+		if (null === $query) {
 			// no query... bail
-			return NULL;
+			return null;
 		}
 
 		$connection = $this->configuration()->readonly_db_connection();
 		$sql = 'SELECT id, user_id, amount, time FROM payments';
 		$where_clause_fragments = array();
 		$parameters = array();
-		if(NULL !== $query->user_id()) {
+		if (null !== $query->user_id()) {
 			$where_clause_fragments[] = 'user_id = :user_id';
 			$parameters[':user_id'] = $query->user_id();
 		}
-		if($query->on_or_after()) {
+		if ($query->on_or_after()) {
 			$where_clause_elements[] = 'time >= :after';
 			$parameters[':after'] = $query->on_or_after();
 		}
-		if($query->on_or_before()) {
+		if ($query->on_or_before()) {
 			$where_clause_elements[] = 'time <= :before';
 			$parameters[':before'] = $query->on_or_before();
 		}
-		if(0 < count($where_clause_fragments)) {
+		if (0 < count($where_clause_fragments)) {
 			$sql .= ' WHERE ';
 			$sql .= join(' AND ', $where_clause_fragments);
 		}
@@ -142,13 +141,13 @@ class PaymentModel extends AbstractModel {
 
 		$statement = $connection->prepare($sql);
 		// run search
-		foreach($parameters as $k => $v) {
+		foreach ($parameters as $k => $v) {
 			$statement->bindValue($k, $v);
 		}
 
-		if($statement->execute()) {
+		if ($statement->execute()) {
 			$data = $statement->fetchAll(PDO::FETCH_ASSOC);
-			if(FALSE !== $data) {
+			if (false !== $data) {
 				return $this->buildPaymentsFromArrays($data);
 			} else {
 				return null;
@@ -169,7 +168,7 @@ class PaymentModel extends AbstractModel {
 	private function buildPaymentsFromArrays(array $data): array {
 		$payments = array();
 
-		foreach($data as $datum) {
+		foreach ($data as $datum) {
 			$payments[] = $this->buildPaymentFromArray($datum);
 		}
 

--- a/src/Model/RoleModel.php
+++ b/src/Model/RoleModel.php
@@ -4,7 +4,6 @@ namespace Portalbox\Model;
 
 use Portalbox\Entity\Role;
 use Portalbox\Exception\DatabaseException;
-
 use PDO;
 
 /**
@@ -27,8 +26,8 @@ class RoleModel extends AbstractModel {
 		$statement->bindValue(':is_system_role', $role->is_system_role(), PDO::PARAM_BOOL);
 		$statement->bindValue(':description', $role->description());
 
-		if($connection->beginTransaction()) {
-			if($statement->execute()) {
+		if ($connection->beginTransaction()) {
+			if ($statement->execute()) {
 				// Add in permissions
 				$role_id = $connection->lastInsertId('roles_id_seq');
 
@@ -37,10 +36,10 @@ class RoleModel extends AbstractModel {
 				$sql = 'INSERT INTO roles_x_permissions (role_id, permission_id) VALUES (:role_id, :permission_id)';
 				$statement = $connection->prepare($sql);
 
-				foreach($permissions as $permission_id) {
+				foreach ($permissions as $permission_id) {
 					$statement->bindValue(':role_id', $role_id, PDO::PARAM_INT);
 					$statement->bindValue(':permission_id', $permission_id, PDO::PARAM_INT);
-					if(!$statement->execute()) {
+					if (!$statement->execute()) {
 						// cancel transaction
 						$connection->rollBack();
 						return null;
@@ -59,7 +58,6 @@ class RoleModel extends AbstractModel {
 		} else {
 			throw new DatabaseException($connection->errorInfo()[2]);
 		}
-
 	}
 
 	/**
@@ -74,14 +72,14 @@ class RoleModel extends AbstractModel {
 		$sql = 'SELECT id, name, is_system_role, description FROM roles WHERE id = :id';
 		$statement = $connection->prepare($sql);
 		$statement->bindValue(':id', $id, PDO::PARAM_INT);
-		if($statement->execute()) {
-			if($data = $statement->fetch(PDO::FETCH_ASSOC)) {
+		if ($statement->execute()) {
+			if ($data = $statement->fetch(PDO::FETCH_ASSOC)) {
 				$role = $this->buildRoleFromArray($data);
 
 				$sql = 'SELECT permission_id FROM roles_x_permissions WHERE role_id = :role_id';
 				$statement = $connection->prepare($sql);
 				$statement->bindValue(':role_id', $data['id'], PDO::PARAM_INT);
-				if($statement->execute()) {
+				if ($statement->execute()) {
 					return $role->set_permissions(array_map('intval', $statement->fetchAll(PDO::FETCH_COLUMN)));
 				}
 
@@ -115,8 +113,8 @@ class RoleModel extends AbstractModel {
 		$statement->bindValue(':is_system_role', $role->is_system_role(), PDO::PARAM_BOOL);
 		$statement->bindValue(':description', $role->description());
 
-		if($connection->beginTransaction()) {
-			if($statement->execute()) {
+		if ($connection->beginTransaction()) {
+			if ($statement->execute()) {
 				// Permissions... There are three cases:
 				//	1) Permissions which were removed -> delete
 				//	2) Permissions which were added -> insert
@@ -130,10 +128,10 @@ class RoleModel extends AbstractModel {
 				$sql = 'INSERT INTO roles_x_permissions (role_id, permission_id) VALUES (:role_id, :permission_id)';
 				$statement = $connection->prepare($sql);
 
-				foreach($added_permissions as $permission_id) {
+				foreach ($added_permissions as $permission_id) {
 					$statement->bindValue(':role_id', $role_id, PDO::PARAM_INT);
 					$statement->bindValue(':permission_id', $permission_id, PDO::PARAM_INT);
-					if(!$statement->execute()) {
+					if (!$statement->execute()) {
 						// cancel transaction
 						$connection->rollBack();
 						return null;
@@ -143,10 +141,10 @@ class RoleModel extends AbstractModel {
 				$sql = 'DELETE FROM roles_x_permissions WHERE role_id = :role_id AND permission_id = :permission_id';
 				$statement = $connection->prepare($sql);
 
-				foreach($removed_permissions as $permission_id) {
+				foreach ($removed_permissions as $permission_id) {
 					$statement->bindValue(':role_id', $role_id, PDO::PARAM_INT);
 					$statement->bindValue(':permission_id', $permission_id, PDO::PARAM_INT);
-					if(!$statement->execute()) {
+					if (!$statement->execute()) {
 						// cancel transaction
 						$connection->rollBack();
 						return null;
@@ -174,17 +172,17 @@ class RoleModel extends AbstractModel {
 	public function delete(int $id): ?Role {
 		$role = $this->read($id);
 
-		if(NULL !== $role) {
-			if($role->is_system_role()) {
+		if (null !== $role) {
+			if ($role->is_system_role()) {
 				// system role must not be deleted
-				return NULL;
+				return null;
 			}
 
 			$connection = $this->configuration()->writable_db_connection();
 			$sql = 'DELETE FROM roles WHERE id = :id';
 			$statement = $connection->prepare($sql);
 			$statement->bindValue(':id', $id, PDO::PARAM_INT);
-			if(!$statement->execute()) {
+			if (!$statement->execute()) {
 				throw new DatabaseException($statement->errorInfo()[2]);
 			}
 		}
@@ -202,9 +200,9 @@ class RoleModel extends AbstractModel {
 		$connection = $this->configuration()->readonly_db_connection();
 		$sql = 'SELECT id, name, is_system_role, description FROM roles';
 		$statement = $connection->prepare($sql);
-		if($statement->execute()) {
+		if ($statement->execute()) {
 			$data = $statement->fetchAll(PDO::FETCH_ASSOC);
-			if(FALSE !== $data) {
+			if (false !== $data) {
 				return $this->buildRolesFromArrays($data);
 			} else {
 				return null;
@@ -225,7 +223,7 @@ class RoleModel extends AbstractModel {
 	private function buildRolesFromArrays(array $data): array {
 		$roles = array();
 
-		foreach($data as $datum) {
+		foreach ($data as $datum) {
 			$roles[] = $this->buildRoleFromArray($datum);
 		}
 

--- a/src/Model/UserModel.php
+++ b/src/Model/UserModel.php
@@ -6,7 +6,6 @@ use Portalbox\Entity\User;
 use Portalbox\Model\Entity\User as PDOAwareUser;
 use Portalbox\Exception\DatabaseException;
 use Portalbox\Query\UserQuery;
-
 use PDO;
 
 /**
@@ -31,8 +30,8 @@ class UserModel extends AbstractModel {
 		$statement->bindValue(':is_active', $user->is_active(), PDO::PARAM_BOOL);
 		$statement->bindValue(':role_id', $user->role()->id(), PDO::PARAM_INT);
 
-		if($connection->beginTransaction()) {
-			if($statement->execute()) {
+		if ($connection->beginTransaction()) {
+			if ($statement->execute()) {
 				// Add in authorizations
 				$user_id = $connection->lastInsertId('users_id_seq');
 
@@ -41,10 +40,10 @@ class UserModel extends AbstractModel {
 				$sql = 'INSERT INTO authorizations (user_id, equipment_type_id) VALUES (:user_id, :equipment_type_id)';
 				$statement = $connection->prepare($sql);
 
-				foreach($authorizations as $equipment_type_id) {
+				foreach ($authorizations as $equipment_type_id) {
 					$statement->bindValue(':user_id', $user_id, PDO::PARAM_INT);
 					$statement->bindValue(':equipment_type_id', $equipment_type_id, PDO::PARAM_INT);
-					if(!$statement->execute()) {
+					if (!$statement->execute()) {
 						// cancel transaction
 						$connection->rollBack();
 						return null;
@@ -77,14 +76,14 @@ class UserModel extends AbstractModel {
 		$sql = 'SELECT u.id, u.name, u.email, u.comment, u.is_active, u.role_id, r.name AS role FROM users AS u INNER JOIN roles AS r ON u.role_id = r.id WHERE u.id = :id';
 		$statement = $connection->prepare($sql);
 		$statement->bindValue(':id', $id, PDO::PARAM_INT);
-		if($statement->execute()) {
-			if($data = $statement->fetch(PDO::FETCH_ASSOC)) {
+		if ($statement->execute()) {
+			if ($data = $statement->fetch(PDO::FETCH_ASSOC)) {
 				$user = $this->buildUserFromArray($data);
 
 				$sql = 'SELECT equipment_type_id FROM authorizations WHERE user_id = :user_id';
 				$query = $connection->prepare($sql);
 				$query->bindValue(':user_id', $data['id'], PDO::PARAM_INT);
-				if($query->execute()) {
+				if ($query->execute()) {
 					return $user->set_authorizations(array_map('intval', $query->fetchAll(PDO::FETCH_COLUMN)));
 				}
 
@@ -120,8 +119,8 @@ class UserModel extends AbstractModel {
 		$statement->bindValue(':is_active', $user->is_active(), PDO::PARAM_BOOL);
 		$statement->bindValue(':role_id', $user->role()->id(), PDO::PARAM_INT);
 
-		if($connection->beginTransaction()) {
-			if($statement->execute()) {
+		if ($connection->beginTransaction()) {
+			if ($statement->execute()) {
 				$user = (new PDOAwareUser($this->configuration()))
 					->set_id($user->id())
 					->set_name($user->name())
@@ -142,10 +141,10 @@ class UserModel extends AbstractModel {
 				$sql = 'INSERT INTO authorizations (user_id, equipment_type_id) VALUES (:user_id, :equipment_type_id)';
 				$statement = $connection->prepare($sql);
 
-				foreach($added_authorizations as $equipment_type_id) {
+				foreach ($added_authorizations as $equipment_type_id) {
 					$statement->bindValue(':user_id', $user_id, PDO::PARAM_INT);
 					$statement->bindValue(':equipment_type_id', $equipment_type_id, PDO::PARAM_INT);
-					if(!$statement->execute()) {
+					if (!$statement->execute()) {
 						// cancel transaction
 						$connection->rollBack();
 						return null;
@@ -155,10 +154,10 @@ class UserModel extends AbstractModel {
 				$sql = 'DELETE FROM authorizations WHERE user_id = :user_id AND equipment_type_id = :equipment_type_id';
 				$statement = $connection->prepare($sql);
 
-				foreach($removed_authorizations as $equipment_type_id) {
+				foreach ($removed_authorizations as $equipment_type_id) {
 					$statement->bindValue(':user_id', $user_id, PDO::PARAM_INT);
 					$statement->bindValue(':equipment_type_id', $equipment_type_id, PDO::PARAM_INT);
-					if(!$statement->execute()) {
+					if (!$statement->execute()) {
 						// cancel transaction
 						$connection->rollBack();
 						return null;
@@ -186,12 +185,12 @@ class UserModel extends AbstractModel {
 	public function delete(int $id): ?User {
 		$user = $this->read($id);
 
-		if(NULL !== $user) {
+		if (null !== $user) {
 			$connection = $this->configuration()->writable_db_connection();
 			$sql = 'DELETE FROM users WHERE id = :id';
 			$statement = $connection->prepare($sql);
 			$statement->bindValue(':id', $id, PDO::PARAM_INT);
-			if(!$statement->execute()) {
+			if (!$statement->execute()) {
 				print_r($connection->errorCode());
 				throw new DatabaseException($connection->errorInfo()[2]);
 			}
@@ -208,9 +207,9 @@ class UserModel extends AbstractModel {
 	 * @return User[]|null - a list of users which match the search query
 	 */
 	public function search(UserQuery $query): ?array {
-		if(NULL === $query) {
+		if (null === $query) {
 			// no query... bail
-			return NULL;
+			return null;
 		}
 
 		$connection = $this->configuration()->readonly_db_connection();
@@ -219,8 +218,8 @@ class UserModel extends AbstractModel {
 		$parameters = array();
 		$modifier = "";
 
-		if(NULL !== $query->include_inactive()) {
-			if($query->include_inactive() === 0) {
+		if (null !== $query->include_inactive()) {
+			if ($query->include_inactive() === 0) {
 				$where_clause_fragments[] = 'u.is_active = :is_active';
 				$parameters[':is_active'] = 1;
 			}
@@ -228,38 +227,38 @@ class UserModel extends AbstractModel {
 			$where_clause_fragments[] = 'u.is_active = :is_active';
 			$parameters[':is_active'] = 1;
 		}
-		if(NULL !== $query->role_id()) {
+		if (null !== $query->role_id()) {
 			$where_clause_fragments[] = 'role_id = :role_id';
 			$parameters[':role_id'] = $query->role_id();
 		}
-		if(NULL !== $query->email()) {
+		if (null !== $query->email()) {
 			$where_clause_fragments[] = 'email = :email';
 			$parameters[':email'] = $query->email();
-		} elseif(NULL !== $query->name()) {
+		} elseif (null !== $query->name()) {
 			$where_clause_fragments[] = 'u.name LIKE :name';
 			$parameters[':name'] = '%' . $query->name() . '%';
-		} elseif(NULL !== $query->comment()) {
+		} elseif (null !== $query->comment()) {
 			$where_clause_fragments[] = 'u.comment LIKE :comment';
 			$parameters[':comment'] = '%' . $query->comment() . '%';
-		} elseif(NULL !== $query->equipment_id()) {
+		} elseif (null !== $query->equipment_id()) {
 			$sql .= ' INNER JOIN authorizations AS a ON u.id = a.user_id';
 			$where_clause_fragments[] = 'a.equipment_type_id = :equipment_id';
 			$parameters[':equipment_id'] = $query->equipment_id();
 		}
-		if(0 < count($where_clause_fragments)) {
+		if (0 < count($where_clause_fragments)) {
 			$sql .= ' WHERE ';
 			$sql .= join(' AND ', $where_clause_fragments);
 		}
 
 		$statement = $connection->prepare($sql);
 		// run search
-		foreach($parameters as $k => $v) {
+		foreach ($parameters as $k => $v) {
 			$statement->bindValue($k, $v);
 		}
 
-		if($statement->execute()) {
+		if ($statement->execute()) {
 			$data = $statement->fetchAll(PDO::FETCH_ASSOC);
-			if(FALSE !== $data) {
+			if (false !== $data) {
 				return $this->buildUsersFromArrays($data);
 			} else {
 				return null;
@@ -283,7 +282,7 @@ class UserModel extends AbstractModel {
 	private function buildUsersFromArrays(array $data): array {
 		$users = array();
 
-		foreach($data as $datum) {
+		foreach ($data as $datum) {
 			$users[] = $this->buildUserFromArray($datum);
 		}
 

--- a/src/Query/APIKeyQuery.php
+++ b/src/Query/APIKeyQuery.php
@@ -34,5 +34,4 @@ class APIKeyQuery {
 		$this->token = $token;
 		return $this;
 	}
-
 }

--- a/src/Query/CardQuery.php
+++ b/src/Query/CardQuery.php
@@ -72,7 +72,7 @@ class CardQuery {
 	 *
 	 * @return int - the card id
 	 */
-	public function id(): ?int  {
+	public function id(): ?int {
 		return $this->id;
 	}
 

--- a/src/ResponseHandler.php
+++ b/src/ResponseHandler.php
@@ -3,7 +3,6 @@
 namespace Portalbox;
 
 use InvalidArgumentException;
-
 use Portalbox\Transform\NullOutputTransformer;
 use Portalbox\Transform\OutputTransformer;
 
@@ -14,7 +13,6 @@ use Portalbox\Transform\OutputTransformer;
  * list_item_to_array.
  */
 class ResponseHandler {
-
 	/**
 	 * Encodes and sends data to the requester
 	 *
@@ -28,13 +26,13 @@ class ResponseHandler {
 	 *     otherwise
 	 */
 	public static function render($data, ?OutputTransformer $transformer = null) {
-		if(NULL === $transformer) {
+		if (null === $transformer) {
 			$transformer = new NullOutputTransformer();
 		}
 
-		if(NULL === $data) {
+		if (null === $data) {
 			throw new InvalidArgumentException('Unable to transform NULL value into response data');
-		} else if(is_array($data)) {
+		} else if (is_array($data)) {
 			self::render_list_response($transformer, $data);
 		} else {
 			self::render_entity_response($transformer, $data);
@@ -49,12 +47,12 @@ class ResponseHandler {
 	 */
 	private static function render_list_response(OutputTransformer $transformer, $data): void {
 		// check request for desired encoding
-		switch($_SERVER['HTTP_ACCEPT']) {
+		switch ($_SERVER['HTTP_ACCEPT']) {
 			case 'text/csv':
 				header('Content-Type: text/csv');
 				$out = fopen('php://output', 'w');
 				fputcsv($out, $transformer->get_column_headers());
-				foreach($data as $list_item) {
+				foreach ($data as $list_item) {
 					fputcsv($out, array_values($transformer->serialize($list_item)));
 				}
 				fclose($out);
@@ -62,12 +60,12 @@ class ResponseHandler {
 			case 'application/json':
 			default:
 				$transformed = [];
-				foreach($data as $list_item) {
+				foreach ($data as $list_item) {
 					$transformed[] = $transformer->serialize($list_item);
 				}
 				$encoded = json_encode($transformed);
 
-				if(false !== $encoded) {
+				if (false !== $encoded) {
 					header('Content-Type: application/json');
 					echo $encoded;
 				} else {
@@ -85,7 +83,7 @@ class ResponseHandler {
 	private static function render_entity_response(OutputTransformer $transformer, $data): void {
 		$encoded = json_encode($transformer->serialize($data, true));
 
-		if(false !== $encoded) {
+		if (false !== $encoded) {
 			header('Content-Type: application/json');
 			echo $encoded;
 		} else {

--- a/src/Session.php
+++ b/src/Session.php
@@ -27,24 +27,25 @@ class Session {
 	 *     is not a currently authenticated user
 	 */
 	public static function get_authenticated_user(): ?User {
-		if(!self::$authenticated_user) {
-
+		if (!self::$authenticated_user) {
 			$config = Config::config();
 
 			// Check for Brearer token
-			if(array_key_exists('HTTP_AUTHORIZATION', $_SERVER) &&
+			if (
+				array_key_exists('HTTP_AUTHORIZATION', $_SERVER) &&
 				8 < strlen($_SERVER['HTTP_AUTHORIZATION']) &&
-				0 == strcmp('Bearer ', substr($_SERVER['HTTP_AUTHORIZATION'], 0 , 7))) {
+				0 == strcmp('Bearer ', substr($_SERVER['HTTP_AUTHORIZATION'], 0, 7))
+			) {
 				$token = substr($_SERVER['HTTP_AUTHORIZATION'], 7);
 
 
 				$model = new APIKeyModel($config);
 
-				$query = (new APIKeyQuery)->set_token($token);
+				$query = (new APIKeyQuery())->set_token($token);
 
 				$keys = $model->search($query);
 
-				if($keys && 0 < count($keys)) {
+				if ($keys && 0 < count($keys)) {
 					// get key 0 and construct a fake user for it.
 					self::$authenticated_user = (new PDOAwareUser($config))
 						->set_name($keys[0]->name())
@@ -58,20 +59,20 @@ class Session {
 			}
 
 			// Check for cookie based session
-			if(PHP_SESSION_ACTIVE !== session_status()) {
+			if (PHP_SESSION_ACTIVE !== session_status()) {
 				$success = session_start();
-				if(!$success) {
+				if (!$success) {
 					session_abort();	// should shutdown execution but just in case...
 					http_response_code(500);
 					die('The operating evnvironment is improperly configured for tracking user sessions. Please notify the administrator');
 				}
 			}
 
-			if(array_key_exists('user_id', $_SESSION)) {
+			if (array_key_exists('user_id', $_SESSION)) {
 				$model = new UserModel($config);
 				self::$authenticated_user = $model->read($_SESSION['user_id']);
 			} else {
-				return NULL;
+				return null;
 			}
 		}
 
@@ -83,7 +84,7 @@ class Session {
 	 * an authenticated user.
 	 */
 	public static function require_authentication() {
-		if(NULL === self::get_authenticated_user()) {
+		if (null === self::get_authenticated_user()) {
 			http_response_code(403);
 			die('Your session is invalid. Perhaps you need to reauthenticate.');
 		}
@@ -111,7 +112,7 @@ class Session {
 	 * not authorized.
 	 */
 	public static function require_authorization(int $permission) {
-		if(!self::check_authorization($permission)) {
+		if (!self::check_authorization($permission)) {
 			http_response_code(403);
 			die('You have not been granted access to this information.');
 		}

--- a/src/Transform/APIKeyTransformer.php
+++ b/src/Transform/APIKeyTransformer.php
@@ -18,7 +18,7 @@ class APIKeyTransformer implements InputTransformer, OutputTransformer {
 	 * @throws InvalidArgumentException if a require field is not specified
 	 */
 	public function deserialize(array $data): APIKey {
-		if(!array_key_exists('name', $data)) {
+		if (!array_key_exists('name', $data)) {
 			throw new InvalidArgumentException('\'name\' is a required field');
 		}
 
@@ -37,7 +37,7 @@ class APIKeyTransformer implements InputTransformer, OutputTransformer {
 	 *      are null, string, int, and float otherwise
 	 */
 	public function serialize($data, bool $traverse = false): array {
-		if($traverse) {
+		if ($traverse) {
 			return [
 				'id' => $data->id(),
 				'name' => $data->name(),

--- a/src/Transform/AuthorizationsTransformer.php
+++ b/src/Transform/AuthorizationsTransformer.php
@@ -3,9 +3,7 @@
 namespace Portalbox\Transform;
 
 use InvalidArgumentException;
-
 use Portalbox\Config;
-
 // violation of SOLID design... should use these via interfaces and dependency injection
 use Portalbox\Model\EquipmentTypeModel;
 
@@ -22,16 +20,16 @@ class AuthorizationsTransformer implements InputTransformer {
 	 * @throws InvalidArgumentException if a required field is not specified
 	 */
 	public function deserialize(array $data): array {
-		if(!array_key_exists('authorizations', $data)) {
+		if (!array_key_exists('authorizations', $data)) {
 			throw new InvalidArgumentException('\'authorizations\' is a required field');
 		}
-		if(!is_array($data['authorizations'])) {
+		if (!is_array($data['authorizations'])) {
 			throw new InvalidArgumentException('\'authorizations\' must be a list of equipment type ids');
 		}
 		$model = new EquipmentTypeModel(Config::config());
-		foreach($data['authorizations'] as $equipment_type_id) {
+		foreach ($data['authorizations'] as $equipment_type_id) {
 			$equipment_type = $model->read($equipment_type_id);
-			if(NULL === $equipment_type) {
+			if (null === $equipment_type) {
 				throw new InvalidArgumentException('\'authorizations\' must be a list of equipment type ids');
 			}
 		}

--- a/src/Transform/CardTransformer.php
+++ b/src/Transform/CardTransformer.php
@@ -3,16 +3,13 @@
 namespace Portalbox\Transform;
 
 use InvalidArgumentException;
-
 use Portalbox\Config;
-
 use Portalbox\Entity\Card;
 use Portalbox\Entity\CardType;
 use Portalbox\Entity\ProxyCard;
 use Portalbox\Entity\ShutdownCard;
 use Portalbox\Entity\TrainingCard;
 use Portalbox\Entity\UserCard;
-
 // violation of SOLID design... should use these via interfaces and dependency injection
 use Portalbox\Model\EquipmentTypeModel;
 use Portalbox\Model\UserModel;
@@ -30,16 +27,16 @@ class CardTransformer implements InputTransformer, OutputTransformer {
 	 * @throws InvalidArgumentException if a require field is not specified
 	 */
 	public function deserialize(array $data): Card {
-		if(!array_key_exists('id', $data)) {
+		if (!array_key_exists('id', $data)) {
 			throw new InvalidArgumentException('\'id\' is a required field');
 		}
-		if(!array_key_exists('type_id', $data)) {
+		if (!array_key_exists('type_id', $data)) {
 			throw new InvalidArgumentException('\'type_id\' is a required field');
 		}
 
-		if(CardType::USER == $data['type_id']) {
+		if (CardType::USER == $data['type_id']) {
 			$user = (new UserModel(Config::config()))->read($data['user_id']);
-			if(NULL === $user) {
+			if (null === $user) {
 				throw new InvalidArgumentException('\'user_id\' must correspond to a valid user');
 			}
 
@@ -48,7 +45,7 @@ class CardTransformer implements InputTransformer, OutputTransformer {
 				->set_user_id($data['user_id']);
 		} else if (CardType::TRAINING == $data['type_id']) {
 			$type = (new EquipmentTypeModel(Config::config()))->read($data['equipment_type_id']);
-			if(NULL === $type) {
+			if (null === $type) {
 				throw new InvalidArgumentException('\'equipment_type_id\' must correspond to a valid equipment type');
 			}
 
@@ -80,15 +77,15 @@ class CardTransformer implements InputTransformer, OutputTransformer {
 	public function serialize($data, bool $traverse = false): array {
 		$card_type_id = $data->type_id();
 
-		if($traverse) {
-			if(CardType::USER == $card_type_id) {
+		if ($traverse) {
+			if (CardType::USER == $card_type_id) {
 				$user_transformer = new UserTransformer();
 				return [
 					'id' => $data->id(),
 					'card_type_id' => $card_type_id,
 					'card_type' => CardType::name_for_type($card_type_id),
-					'user' => is_null($data->user()) ? NULL : $user_transformer->serialize($data->user(), $traverse),
-					'equipment_type' => NULL
+					'user' => is_null($data->user()) ? null : $user_transformer->serialize($data->user(), $traverse),
+					'equipment_type' => null
 				];
 			} else if (CardType::TRAINING == $card_type_id) {
 				$equipment_type_transformer = new EquipmentTypeTransformer();
@@ -96,28 +93,28 @@ class CardTransformer implements InputTransformer, OutputTransformer {
 					'id' => $data->id(),
 					'card_type_id' => $card_type_id,
 					'card_type' => CardType::name_for_type($card_type_id),
-					'user' => NULL,
-					'equipment_type' => is_null($data->equipment_type()) ? NULL : $equipment_type_transformer->serialize($data->equipment_type(), $traverse)
+					'user' => null,
+					'equipment_type' => is_null($data->equipment_type()) ? null : $equipment_type_transformer->serialize($data->equipment_type(), $traverse)
 				];
 			} else if (CardType::PROXY == $card_type_id) {
 				return [
 					'id' => $data->id(),
 					'card_type_id' => $card_type_id,
 					'card_type' => CardType::name_for_type($card_type_id),
-					'user' => NULL,
-					'equipment_type' => NULL
+					'user' => null,
+					'equipment_type' => null
 				];
 			} else if (CardType::SHUTDOWN == $card_type_id) {
 				return [
 					'id' => $data->id(),
 					'card_type_id' => $card_type_id,
 					'card_type' => CardType::name_for_type($card_type_id),
-					'user' => NULL,
-					'equipment_type' => NULL
+					'user' => null,
+					'equipment_type' => null
 				];
 			}
 		} else {
-			if(CardType::USER == $card_type_id) {
+			if (CardType::USER == $card_type_id) {
 				return [
 					'id' => $data->id(),
 					'card_type_id' => $card_type_id,

--- a/src/Transform/CardTypeTransformer.php
+++ b/src/Transform/CardTypeTransformer.php
@@ -6,30 +6,30 @@ use InvalidArgumentException;
 use Portalbox\Entity\CardType;
 
 class CardTypeTransformer implements InputTransformer, OutputTransformer {
-    public function deserialize(array $data): CardType {
-        if(!array_key_exists('id', $data)) {
-            throw new InvalidArgumentException('\'id\' is a required field');
-        }
+	public function deserialize(array $data): CardType {
+		if (!array_key_exists('id', $data)) {
+			throw new InvalidArgumentException('\'id\' is a required field');
+		}
 
-        return (new CardType())
-            ->set_id($data['id']);
-    }
+		return (new CardType())
+			->set_id($data['id']);
+	}
 
-    public function serialize($data, bool $traverse = false): array {
-        if($traverse) {
-            return [
-                'id' => $data->id(),
-                'name' => $data->name()
-            ];
-        } else {
-            return [
-                'id' => $data->id(),
-                'name' => $data->name()
-            ];
-        }
-    }
+	public function serialize($data, bool $traverse = false): array {
+		if ($traverse) {
+			return [
+				'id' => $data->id(),
+				'name' => $data->name()
+			];
+		} else {
+			return [
+				'id' => $data->id(),
+				'name' => $data->name()
+			];
+		}
+	}
 
-    public function get_column_headers(): array {
-        return ['id', 'Name'];
-    }
+	public function get_column_headers(): array {
+		return ['id', 'Name'];
+	}
 }

--- a/src/Transform/ChargeTransformer.php
+++ b/src/Transform/ChargeTransformer.php
@@ -3,12 +3,9 @@
 namespace Portalbox\Transform;
 
 use InvalidArgumentException;
-
 use Portalbox\Config;
-
 use Portalbox\Entity\Charge;
 use Portalbox\Entity\ChargePolicy;
-
 // violation of SOLID design... should use these via interfaces and dependency injection
 use Portalbox\Model\EquipmentModel;
 use Portalbox\Model\UserModel;
@@ -26,37 +23,37 @@ class ChargeTransformer implements InputTransformer, OutputTransformer {
 	 * @throws InvalidArgumentException if a require field is not specified
 	 */
 	public function deserialize(array $data): Charge {
-		if(!array_key_exists('equipment_id', $data)) {
+		if (!array_key_exists('equipment_id', $data)) {
 			throw new InvalidArgumentException('\'equipment_id\' is a required field');
 		}
-		if(!array_key_exists('user_id', $data)) {
+		if (!array_key_exists('user_id', $data)) {
 			throw new InvalidArgumentException('\'user_id\' is a required field');
 		}
-		if(!array_key_exists('amount', $data)) {
+		if (!array_key_exists('amount', $data)) {
 			throw new InvalidArgumentException('\'amount\' is a required field');
 		}
-		if(!array_key_exists('time', $data)) {
+		if (!array_key_exists('time', $data)) {
 			throw new InvalidArgumentException('\'time\' is a required field');
 		}
-		if(!array_key_exists('charge_policy_id', $data)) {
+		if (!array_key_exists('charge_policy_id', $data)) {
 			throw new InvalidArgumentException('\'charge_policy_id\' is a required field');
 		}
-		if(!ChargePolicy::is_valid($data['charge_policy_id'])) {
+		if (!ChargePolicy::is_valid($data['charge_policy_id'])) {
 			throw new InvalidArgumentException('\'charge_policy_id\' must be a valid charge policy id');
 		}
-		if(!array_key_exists('charge_rate', $data)) {
+		if (!array_key_exists('charge_rate', $data)) {
 			throw new InvalidArgumentException('\'charge_rate\' is a required field');
 		}
-		if(!array_key_exists('charged_time', $data)) {
+		if (!array_key_exists('charged_time', $data)) {
 			throw new InvalidArgumentException('\'charged_time\' is a required field');
 		}
 
 		$equipment = (new EquipmentModel(Config::config()))->read($data['equipment_id']);
-		if(NULL === $equipment) {
+		if (null === $equipment) {
 			throw new InvalidArgumentException('\'equipment_id\' must correspond to a valid equipment');
 		}
 		$user = (new UserModel(Config::config()))->read($data['user_id']);
-		if(NULL === $user) {
+		if (null === $user) {
 			throw new InvalidArgumentException('\'user_id\' must correspond to a valid user');
 		}
 
@@ -81,7 +78,7 @@ class ChargeTransformer implements InputTransformer, OutputTransformer {
 	 *      are null, string, int, and float otherwise
 	 */
 	public function serialize($data, bool $traverse = false): array {
-		if($traverse) {
+		if ($traverse) {
 			$equipment_transformer = new EquipmentTransformer();
 			$user_transformer = new UserTransformer();
 

--- a/src/Transform/EquipmentTransformer.php
+++ b/src/Transform/EquipmentTransformer.php
@@ -3,11 +3,8 @@
 namespace Portalbox\Transform;
 
 use InvalidArgumentException;
-
 use Portalbox\Config;
-
 use Portalbox\Entity\Equipment;
-
 // violation of SOLID design... should use these via interfaces and dependency injection
 use Portalbox\Model\EquipmentTypeModel;
 use Portalbox\Model\LocationModel;
@@ -25,37 +22,37 @@ class EquipmentTransformer implements InputTransformer, OutputTransformer {
 	 * @throws InvalidArgumentException if a require field is not specified
 	 */
 	public function deserialize(array $data): Equipment {
-		if(!array_key_exists('name', $data)) {
+		if (!array_key_exists('name', $data)) {
 			throw new InvalidArgumentException('\'name\' is a required field');
 		}
-		if(!array_key_exists('type_id', $data)) {
+		if (!array_key_exists('type_id', $data)) {
 			throw new InvalidArgumentException('\'type_id\' is a required field');
 		}
-		if(!array_key_exists('location_id', $data)) {
+		if (!array_key_exists('location_id', $data)) {
 			throw new InvalidArgumentException('\'location_id\' is a required field');
 		}
-		if(!array_key_exists('mac_address', $data)) {
+		if (!array_key_exists('mac_address', $data)) {
 			throw new InvalidArgumentException('\'mac_address\' is a required field');
 		}
-		if(!array_key_exists('timeout', $data)) {
+		if (!array_key_exists('timeout', $data)) {
 			throw new InvalidArgumentException('\'timeout\' is a required field');
 		}
-		if(!array_key_exists('in_service', $data)) {
+		if (!array_key_exists('in_service', $data)) {
 			throw new InvalidArgumentException('\'in_service\' is a required field');
 		}
 
 		// service minutes is optional and should default to 0
 		$service_minutes = 0;
-		if(array_key_exists('service_minutes', $data)) {
+		if (array_key_exists('service_minutes', $data)) {
 			$service_minutes = intval($data["service_minutes"]);
 		}
 
 		$type = (new EquipmentTypeModel(Config::config()))->read($data['type_id']);
-		if(NULL === $type) {
+		if (null === $type) {
 			throw new InvalidArgumentException('\'type_id\' must correspond to a valid equipment type');
 		}
 		$location = (new LocationModel(Config::config()))->read($data['location_id']);
-		if(NULL === $location) {
+		if (null === $location) {
 			throw new InvalidArgumentException('\'location_id\' must correspond to a valid location');
 		}
 
@@ -80,13 +77,13 @@ class EquipmentTransformer implements InputTransformer, OutputTransformer {
 	 *      are null, string, int, and float otherwise
 	 */
 	public function serialize($data, bool $traverse = false): array {
-		if($traverse) {
+		if ($traverse) {
 			return [
 				'id' => $data->id(),
 				'name' => $data->name(),
 				'type_id' => $data->type_id(),
 				'type' => $data->type()->name(),
-				'mac_address' => is_null($data->mac_address()) ? NULL :$data->mac_address(),
+				'mac_address' => is_null($data->mac_address()) ? null : $data->mac_address(),
 				'location_id' => $data->location_id(),
 				'location' => $data->location()->name(),
 				'timeout' => $data->timeout(),
@@ -100,7 +97,7 @@ class EquipmentTransformer implements InputTransformer, OutputTransformer {
 				'id' => $data->id(),
 				'name' => $data->name(),
 				'type' => $data->type()->name(),
-				'mac_address' => is_null($data->mac_address()) ? '' :$data->mac_address(),
+				'mac_address' => is_null($data->mac_address()) ? '' : $data->mac_address(),
 				'location' => $data->location()->name(),
 				'timeout' => $data->timeout(),
 				'in_service' => $data->is_in_service(),

--- a/src/Transform/EquipmentTypeTransformer.php
+++ b/src/Transform/EquipmentTypeTransformer.php
@@ -3,7 +3,6 @@
 namespace Portalbox\Transform;
 
 use InvalidArgumentException;
-
 use Portalbox\Entity\ChargePolicy;
 use Portalbox\Entity\EquipmentType;
 
@@ -20,22 +19,22 @@ class EquipmentTypeTransformer implements InputTransformer, OutputTransformer {
 	 * @throws InvalidArgumentException if a require field is not specified
 	 */
 	public function deserialize(array $data): EquipmentType {
-		if(!array_key_exists('name', $data)) {
+		if (!array_key_exists('name', $data)) {
 			throw new InvalidArgumentException('\'name\' is a required field');
 		}
-		if(!array_key_exists('requires_training', $data)) {
+		if (!array_key_exists('requires_training', $data)) {
 			throw new InvalidArgumentException('\'requires_training\' is a required field');
 		}
-		if(!array_key_exists('charge_policy_id', $data)) {
+		if (!array_key_exists('charge_policy_id', $data)) {
 			throw new InvalidArgumentException('\'charge_policy_id\' is a required field');
 		}
-		if(!ChargePolicy::is_valid($data['charge_policy_id'])) {
+		if (!ChargePolicy::is_valid($data['charge_policy_id'])) {
 			throw new InvalidArgumentException('\'charge_policy_id\' must be a valid charge policy id');
 		}
-		if(!array_key_exists('charge_rate', $data)) {
+		if (!array_key_exists('charge_rate', $data)) {
 			throw new InvalidArgumentException('\'charge_rate\' is a required field');
 		}
-		if(!array_key_exists('allow_proxy', $data)) {
+		if (!array_key_exists('allow_proxy', $data)) {
 			throw new InvalidArgumentException('\'allow_proxy\' is a required field');
 		}
 
@@ -59,7 +58,7 @@ class EquipmentTypeTransformer implements InputTransformer, OutputTransformer {
 	 *      are null, string, int, and float otherwise
 	 */
 	public function serialize($data, bool $traverse = false): array {
-		if($traverse) {
+		if ($traverse) {
 			return [
 				'id' => $data->id(),
 				'name' => $data->name(),

--- a/src/Transform/LocationTransformer.php
+++ b/src/Transform/LocationTransformer.php
@@ -3,7 +3,6 @@
 namespace Portalbox\Transform;
 
 use InvalidArgumentException;
-
 use Portalbox\Entity\Location;
 
 /**
@@ -19,7 +18,7 @@ class LocationTransformer implements InputTransformer, OutputTransformer {
 	 * @throws InvalidArgumentException if a require field is not specified
 	 */
 	public function deserialize(array $data): Location {
-		if(!array_key_exists('name', $data)) {
+		if (!array_key_exists('name', $data)) {
 			throw new InvalidArgumentException('\'name\' is a required field');
 		}
 
@@ -37,7 +36,7 @@ class LocationTransformer implements InputTransformer, OutputTransformer {
 	 *      are null, string, int, and float otherwise
 	 */
 	public function serialize($data, bool $traverse = false): array {
-		if($traverse) {
+		if ($traverse) {
 			return [
 				'id' => $data->id(),
 				'name' => $data->name()

--- a/src/Transform/LoggedEventTransformer.php
+++ b/src/Transform/LoggedEventTransformer.php
@@ -7,7 +7,6 @@ namespace Portalbox\Transform;
  * LoggedEvent entity instances.
  */
 class LoggedEventTransformer implements OutputTransformer {
-
 	/**
 	 * Called to serialize LoggedEvent entity instance to a dictionary
 	 *
@@ -19,7 +18,7 @@ class LoggedEventTransformer implements OutputTransformer {
 	 *      are null, string, int, and float otherwise
 	 */
 	public function serialize($data, bool $traverse = false): array {
-		if($traverse) {
+		if ($traverse) {
 			$equipment_transformer = new EquipmentTransformer();
 			$user_transformer = new UserTransformer();
 			return [
@@ -34,7 +33,7 @@ class LoggedEventTransformer implements OutputTransformer {
 			return [
 				'id' => $data->id(),
 				'time' => $data->time(),
-				'type' =>$data->type(),
+				'type' => $data->type(),
 				'card' => $data->card_id(),
 				'user' => $data->user_name(),
 				'equipment_name' => $data->equipment_name(),

--- a/src/Transform/NullOutputTransformer.php
+++ b/src/Transform/NullOutputTransformer.php
@@ -21,7 +21,6 @@ class NullOutputTransformer implements OutputTransformer {
 	 */
 	public function serialize($data, bool $traverse = false): array {
 		return $data;
-
 	}
 
 	/**

--- a/src/Transform/OutputTransformer.php
+++ b/src/Transform/OutputTransformer.php
@@ -7,7 +7,6 @@ namespace Portalbox\Transform;
  * Transformed into a variety of output encodings
  */
 interface OutputTransformer {
-
 	/**
 	 * Called to serialize an entity
 	 *

--- a/src/Transform/PaymentTransformer.php
+++ b/src/Transform/PaymentTransformer.php
@@ -3,11 +3,8 @@
 namespace Portalbox\Transform;
 
 use InvalidArgumentException;
-
 use Portalbox\Config;
-
 use Portalbox\Entity\Payment;
-
 // violation of SOLID design... should use these via interfaces and dependency injection
 use Portalbox\Model\UserModel;
 
@@ -24,18 +21,18 @@ class PaymentTransformer implements InputTransformer, OutputTransformer {
 	 * @throws InvalidArgumentException if a require field is not specified
 	 */
 	public function deserialize(array $data): Payment {
-		if(!array_key_exists('user_id', $data)) {
+		if (!array_key_exists('user_id', $data)) {
 			throw new InvalidArgumentException('\'user_id\' is a required field');
 		}
-		if(!array_key_exists('amount', $data)) {
+		if (!array_key_exists('amount', $data)) {
 			throw new InvalidArgumentException('\'amount\' is a required field');
 		}
-		if(!array_key_exists('time', $data)) {
+		if (!array_key_exists('time', $data)) {
 			throw new InvalidArgumentException('\'time\' is a required field');
 		}
 
 		$user = (new UserModel(Config::config()))->read($data['user_id']);
-		if(NULL === $user) {
+		if (null === $user) {
 			throw new InvalidArgumentException('\'user_id\' must correspond to a valid user');
 		}
 
@@ -56,7 +53,7 @@ class PaymentTransformer implements InputTransformer, OutputTransformer {
 	 *      are null, string, int, and float otherwise
 	 */
 	public function serialize($data, bool $traverse = false): array {
-		if($traverse) {
+		if ($traverse) {
 			return [
 				'id' => $data->id(),
 				'user_id' => $data->user_id(),

--- a/src/Transform/RoleTransformer.php
+++ b/src/Transform/RoleTransformer.php
@@ -18,13 +18,13 @@ class RoleTransformer implements InputTransformer, OutputTransformer {
 	 * @throws InvalidArgumentException if a require field is not specified
 	 */
 	public function deserialize(array $data): Role {
-		if(!array_key_exists('name', $data)) {
+		if (!array_key_exists('name', $data)) {
 			throw new InvalidArgumentException('\'name\' is a required field');
 		}
-		if(!array_key_exists('description', $data)) {
+		if (!array_key_exists('description', $data)) {
 			throw new InvalidArgumentException('\'description\' is a required field');
 		}
-		if(!array_key_exists('permissions', $data)) {
+		if (!array_key_exists('permissions', $data)) {
 			throw new InvalidArgumentException('\'permissions\' is a required field');
 		}
 
@@ -46,7 +46,7 @@ class RoleTransformer implements InputTransformer, OutputTransformer {
 	 *      are null, string, int, and float otherwise
 	 */
 	public function serialize($data, bool $traverse = false): array {
-		if($traverse) {
+		if ($traverse) {
 			return [
 				'id' => $data->id(),
 				'name' => $data->name(),

--- a/src/Transform/UserTransformer.php
+++ b/src/Transform/UserTransformer.php
@@ -3,11 +3,8 @@
 namespace Portalbox\Transform;
 
 use InvalidArgumentException;
-
 use Portalbox\Config;
-
 use Portalbox\Entity\User;
-
 // violation of SOLID design... should use these via interfaces and dependency injection
 use Portalbox\Model\EquipmentTypeModel;
 use Portalbox\Model\RoleModel;
@@ -25,21 +22,21 @@ class UserTransformer implements InputTransformer, OutputTransformer {
 	 * @throws InvalidArgumentException if a require field is not specified
 	 */
 	public function deserialize(array $data): User {
-		if(!array_key_exists('role_id', $data)) {
+		if (!array_key_exists('role_id', $data)) {
 			throw new InvalidArgumentException('\'role_id\' is a required field');
 		}
-		if(!array_key_exists('name', $data)) {
+		if (!array_key_exists('name', $data)) {
 			throw new InvalidArgumentException('\'name\' is a required field');
 		}
-		if(!array_key_exists('email', $data)) {
+		if (!array_key_exists('email', $data)) {
 			throw new InvalidArgumentException('\'email\' is a required field');
 		}
-		if(!array_key_exists('is_active', $data)) {
+		if (!array_key_exists('is_active', $data)) {
 			throw new InvalidArgumentException('\'is_active\' is a required field');
 		}
 
 		$role = (new RoleModel(Config::config()))->read($data['role_id']);
-		if(NULL === $role) {
+		if (null === $role) {
 			throw new InvalidArgumentException('\'role_id\' must correspond to a valid role');
 		}
 
@@ -50,18 +47,18 @@ class UserTransformer implements InputTransformer, OutputTransformer {
 					->set_role($role);
 
 		// add in optional fields
-		if(array_key_exists('comment', $data)) {
+		if (array_key_exists('comment', $data)) {
 			$user->set_comment($data['comment']);
 		}
-		if(array_key_exists('authorizations', $data)) {
-			if(!is_array($data['authorizations'])) {
+		if (array_key_exists('authorizations', $data)) {
+			if (!is_array($data['authorizations'])) {
 				throw new InvalidArgumentException('\'authorizations\' must be a list of equipment type ids');
 			}
 
 			$model = new EquipmentTypeModel(Config::config());
-			foreach($data['authorizations'] as $equipment_type_id) {
+			foreach ($data['authorizations'] as $equipment_type_id) {
 				$equipment_type = $model->read($equipment_type_id);
-				if(NULL === $equipment_type) {
+				if (null === $equipment_type) {
 					throw new InvalidArgumentException('\'authorizations\' must be a list of equipment type ids');
 				}
 			}
@@ -83,14 +80,14 @@ class UserTransformer implements InputTransformer, OutputTransformer {
 	 *      are null, string, int, and float otherwise
 	 */
 	public function serialize($data, bool $traverse = false): array {
-		if($traverse) {
+		if ($traverse) {
 			$role_transformer = new RoleTransformer();
 			return [
 				'id' => $data->id(),
 				'name' => $data->name(),
 				'email' => $data->email(),
 				'comment' => $data->comment(),
-				'role' => is_null($data->role()) ? NULL : $role_transformer->serialize($data->role(), $traverse),
+				'role' => is_null($data->role()) ? null : $role_transformer->serialize($data->role(), $traverse),
 				'is_active' => $data->is_active(),
 				'authorizations' => $data->authorizations()
 			];

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -1,9 +1,9 @@
 <?php
 
-spl_autoload_register(function($class_name) {
+spl_autoload_register(function ($class_name) {
 	$fragments = explode('\\', $class_name);
 
-	if(0 < count($fragments) && 'Portalbox' == $fragments[0]) {
+	if (0 < count($fragments) && 'Portalbox' == $fragments[0]) {
 		$fragments[0] = __DIR__;
 
 		require join(DIRECTORY_SEPARATOR, $fragments) . '.php';

--- a/test/Entity/CardTest.php
+++ b/test/Entity/CardTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Entity\CardType;
 use Portalbox\Entity\ProxyCard;
 use Portalbox\Entity\ShutdownCard;

--- a/test/Entity/Charge.php
+++ b/test/Entity/Charge.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Entity\Charge;
 use Portalbox\Entity\Equipment;
 use Portalbox\Entity\User;

--- a/test/Entity/ChargePolicyTest.php
+++ b/test/Entity/ChargePolicyTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Entity\ChargePolicy;
 
 final class ChargePolicyTest extends TestCase {

--- a/test/Entity/EquipmentTest.php
+++ b/test/Entity/EquipmentTest.php
@@ -82,12 +82,12 @@ final class EquipmentTest extends TestCase {
 		self::assertEquals($location, $equipment->location());
 	}
 
-	public function testThrowsExceptionOnInvalidName():void {
+	public function testThrowsExceptionOnInvalidName(): void {
 		self::expectException(InvalidArgumentException::class);
 		(new Equipment())->set_name('');
 	}
 
-	public function testThrowsExceptionOnInvalidMACAddress():void {
+	public function testThrowsExceptionOnInvalidMACAddress(): void {
 		self::expectException(InvalidArgumentException::class);
 		(new Equipment())->set_mac_address('OO:OO:OO:OO:OO:OO'); // Capital O not 0
 	}

--- a/test/Entity/EquipmentTypeTest.php
+++ b/test/Entity/EquipmentTypeTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Entity\ChargePolicy;
 use Portalbox\Entity\EquipmentType;
 
@@ -11,7 +10,7 @@ final class EquipmentTypeTest extends TestCase {
 	public function testAgreement(): void {
 		$id = 42;
 		$name = 'laser scalpel';
-		$requires_training = TRUE;
+		$requires_training = true;
 		$charge_rate = "2.50";
 		$charge_policy_id = ChargePolicy::PER_USE;
 		$allow_proxy = true;

--- a/test/Entity/LoggedEventTest.php
+++ b/test/Entity/LoggedEventTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Entity\UserCard;
 use Portalbox\Entity\Equipment;
 use Portalbox\Entity\Location;

--- a/test/Entity/LoggedEventTypeTest.php
+++ b/test/Entity/LoggedEventTypeTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Entity\LoggedEventType;
 
 final class LoggedEventTypeTest extends TestCase {

--- a/test/Entity/PaymentTest.php
+++ b/test/Entity/PaymentTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Entity\Payment;
 
 final class PaymentTest extends TestCase {

--- a/test/Entity/RoleTest.php
+++ b/test/Entity/RoleTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Entity\Permission;
 use Portalbox\Entity\Role;
 
@@ -11,7 +10,7 @@ final class RoleTest extends TestCase {
 	public function testAgreement(): void {
 		$id = 42;
 		$name = 'admin';
-		$is_system_role = TRUE;
+		$is_system_role = true;
 		$description = 'Users with this role have no restrictions.';
 		$permissions = array(
 			Permission::READ_API_KEY,

--- a/test/Entity/UserTest.php
+++ b/test/Entity/UserTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Entity\User;
 
 final class UserTest extends TestCase {
@@ -12,7 +11,7 @@ final class UserTest extends TestCase {
 		$name = 'Tom Egan';
 		$email = 'tom@tomegan.tech';
 		$comment = 'Test Monkey';
-		$active = FALSE;
+		$active = false;
 		$authorizations = array(
 			34,
 			23

--- a/test/Model/APIKeyModelTest.php
+++ b/test/Model/APIKeyModelTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Config;
 use Portalbox\Entity\APIKey;
 use Portalbox\Model\APIKeyModel;
@@ -44,7 +43,7 @@ final class APIKeyModelTest extends TestCase {
 		self::assertEquals($name, $key_as_modified->name());
 		self::assertEquals($token, $key_as_modified->token());
 
-		$query = (new APIKeyQuery)->set_token($token);
+		$query = (new APIKeyQuery())->set_token($token);
 		$keys_as_found = $model->search($query);
 		self::assertNotNull($keys_as_found);
 		self::assertIsIterable($keys_as_found);

--- a/test/Model/CardModelTest.php
+++ b/test/Model/CardModelTest.php
@@ -3,9 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Config;
-
 use Portalbox\Entity\CardType;
 use Portalbox\Entity\ChargePolicy;
 use Portalbox\Entity\EquipmentType;
@@ -16,12 +14,10 @@ use Portalbox\Entity\ShutdownCard;
 use Portalbox\Entity\TrainingCard;
 use Portalbox\Entity\User;
 use Portalbox\Entity\UserCard;
-
 use Portalbox\Model\CardModel;
 use Portalbox\Model\EquipmentTypeModel;
 use Portalbox\Model\LocationModel;
 use Portalbox\Model\UserModel;
-
 use Portalbox\Query\CardQuery;
 
 final class CardModelTest extends TestCase {
@@ -64,7 +60,7 @@ final class CardModelTest extends TestCase {
 		$model = new EquipmentTypeModel(self::$config);
 
 		$name = 'Floodlight';
-		$requires_training = FALSE;
+		$requires_training = false;
 		$charge_policy_id = ChargePolicy::NO_CHARGE;
 
 		$equipment_type = (new EquipmentType())
@@ -86,7 +82,7 @@ final class CardModelTest extends TestCase {
 		$name = 'Tom Egan';
 		$email = 'tom@ficticious.tld';
 		$comment = 'Test Monkey';
-		$active = TRUE;
+		$active = true;
 
 		$user = (new User())
 			->set_name($name)

--- a/test/Model/ChargeModelTest.php
+++ b/test/Model/ChargeModelTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Config;
 use Portalbox\Entity\Charge;
 use Portalbox\Entity\ChargePolicy;
@@ -62,7 +61,7 @@ final class ChargeModelTest extends TestCase {
 		$name = 'Tom Egan';
 		$email = 'tom@ficticious.tld';
 		$comment = 'Test Monkey';
-		$active = TRUE;
+		$active = true;
 
 		$user = (new User())
 			->set_name($name)
@@ -87,7 +86,7 @@ final class ChargeModelTest extends TestCase {
 		$model = new EquipmentTypeModel(self::$config);
 
 		$name = 'Floodlight';
-		$requires_training = FALSE;
+		$requires_training = false;
 		$charge_policy_id = ChargePolicy::NO_CHARGE;
 
 		$type = (new EquipmentType())
@@ -104,7 +103,7 @@ final class ChargeModelTest extends TestCase {
 		$name = '1000W Floodlight';
 		$mac_address = '0123456789AB';
 		$timeout = 0;
-		$is_in_service = TRUE;
+		$is_in_service = true;
 		$service_minutes = 500;
 
 		$equipment = (new Equipment())

--- a/test/Model/EquipmentModelTest.php
+++ b/test/Model/EquipmentModelTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Config;
 use Portalbox\Entity\ChargePolicy;
 use Portalbox\Entity\Equipment;
@@ -49,7 +48,7 @@ final class EquipmentModelTest extends TestCase {
 		$model = new EquipmentTypeModel(self::$config);
 
 		$name = 'Floodlight';
-		$requires_training = FALSE;
+		$requires_training = false;
 		$charge_policy_id = ChargePolicy::NO_CHARGE;
 
 		$type = (new EquipmentType())
@@ -79,7 +78,7 @@ final class EquipmentModelTest extends TestCase {
 		$name = '1000W Floodlight';
 		$mac_address = '0123456789ab';
 		$timeout = 0;
-		$is_in_service = TRUE;
+		$is_in_service = true;
 		$service_minutes = 500;
 
 		$equipment = (new Equipment())
@@ -120,7 +119,7 @@ final class EquipmentModelTest extends TestCase {
 		$name = '2000W Floodlight';
 		$mac_address = 'cdef456789ab';
 		$timeout = 120;
-		$is_in_service = FALSE;
+		$is_in_service = false;
 		$service_minutes = 700;
 
 		$equipment_as_found
@@ -165,7 +164,7 @@ final class EquipmentModelTest extends TestCase {
 		$name = '1000W Floodlight';
 		$mac_address = '0123456789AB';
 		$timeout = 0;
-		$is_in_service = TRUE;
+		$is_in_service = true;
 		$service_minutes = 500;
 
 		$equipment = (new Equipment())

--- a/test/Model/EquipmentTypeModelTest.php
+++ b/test/Model/EquipmentTypeModelTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Config;
 use Portalbox\Entity\ChargePolicy;
 use Portalbox\Entity\EquipmentType;
@@ -14,7 +13,7 @@ final class EquipmentTypeModelTest extends TestCase {
 		$model = new EquipmentTypeModel(Config::config());
 
 		$name = 'ceramics printer';
-		$requires_training = TRUE;
+		$requires_training = true;
 		$charge_rate = "0.01";
 		$charge_policy_id = ChargePolicy::PER_MINUTE;
 		$allow_proxy = true;
@@ -47,7 +46,7 @@ final class EquipmentTypeModelTest extends TestCase {
 		self::assertEquals($allow_proxy, $type_as_found->allow_proxy());
 
 		$name = '3D Clay Printer';
-		$requires_training = FALSE;
+		$requires_training = false;
 		$charge_rate = '2.50';
 		$charge_policy_id = ChargePolicy::PER_USE;
 		$allow_proxy = false;

--- a/test/Model/LocationModelTest.php
+++ b/test/Model/LocationModelTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Config;
 use Portalbox\Entity\Location;
 use Portalbox\Model\LocationModel;

--- a/test/Model/LoggedEventModelTest.php
+++ b/test/Model/LoggedEventModelTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Config;
 use Portalbox\Entity\ChargePolicy;
 use Portalbox\Entity\Equipment;
@@ -67,7 +66,7 @@ final class LoggedEventModelTest extends TestCase {
 		$model = new EquipmentTypeModel(self::$config);
 
 		$name = 'Floodlight';
-		$requires_training = FALSE;
+		$requires_training = false;
 		$charge_policy_id = ChargePolicy::NO_CHARGE;
 
 		self::$type = $model->create(
@@ -84,7 +83,7 @@ final class LoggedEventModelTest extends TestCase {
 		$name = '1000W Floodlight';
 		$mac_address = '0123456789ab';
 		$timeout = 0;
-		$is_in_service = TRUE;
+		$is_in_service = true;
 		$service_minutes = 500;
 
 		self::$equipment = $model->create(

--- a/test/Model/PaymentModelTest.php
+++ b/test/Model/PaymentModelTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Config;
 use Portalbox\Entity\Payment;
 use Portalbox\Entity\Role;
@@ -39,7 +38,7 @@ final class PaymentModelTest extends TestCase {
 		$name = 'Tom Egan';
 		$email = 'tom@ficticious.tld';
 		$comment = 'Test Monkey';
-		$active = TRUE;
+		$active = true;
 
 		$user = (new User())
 			->set_name($name)

--- a/test/Model/RoleModelTest.php
+++ b/test/Model/RoleModelTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Config;
 use Portalbox\Entity\Permission;
 use Portalbox\Entity\Role;
@@ -14,7 +13,7 @@ final class RoleModelTest extends TestCase {
 		$model = new RoleModel(Config::config());
 
 		$name = 'Test Role';
-		$is_system_role = FALSE;
+		$is_system_role = false;
 		$description = 'A pointless role';
 
 		$role = (new Role())

--- a/test/Model/UserModelTest.php
+++ b/test/Model/UserModelTest.php
@@ -3,17 +3,13 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Config;
-
 use Portalbox\Entity\ChargePolicy;
 use Portalbox\Entity\EquipmentType;
 use Portalbox\Entity\Role;
 use Portalbox\Entity\User;
-
 use Portalbox\Model\EquipmentTypeModel;
 use Portalbox\Model\UserModel;
-
 use Portalbox\Query\UserQuery;
 
 final class UserModelTest extends TestCase {
@@ -36,7 +32,7 @@ final class UserModelTest extends TestCase {
 		$model = new EquipmentTypeModel(self::$config);
 
 		$name = 'Floodlight';
-		$requires_training = FALSE;
+		$requires_training = false;
 		$charge_policy_id = ChargePolicy::NO_CHARGE;
 
 		$type = (new EquipmentType())
@@ -67,7 +63,7 @@ final class UserModelTest extends TestCase {
 		$name = 'Tom Egan';
 		$email = 'tom@ficticious.tld';
 		$comment = 'Test Monkey';
-		$active = FALSE;
+		$active = false;
 		$authorizations = [self::$type->id()];
 		$num_authorizations = count($authorizations);
 
@@ -108,7 +104,7 @@ final class UserModelTest extends TestCase {
 		$name = 'Matt Lamparter';
 		$email = 'matt@ficticious.tld';
 		$comment = 'Test Hominid';
-		$active = TRUE;
+		$active = true;
 
 		$user_as_found
 			->set_name($name)
@@ -126,7 +122,7 @@ final class UserModelTest extends TestCase {
 		self::assertEquals($active, $user_as_modified->is_active());
 		self::assertEquals($role_id, $user_as_modified->role()->id());
 
-		$query = (new UserQuery)->set_email($email);
+		$query = (new UserQuery())->set_email($email);
 		$users_as_found = $model->search($query);
 		self::assertNotNull($users_as_found);
 		self::assertIsIterable($users_as_found);

--- a/test/Query/APIKeyQueryTest.php
+++ b/test/Query/APIKeyQueryTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Query\APIKeyQuery;
 
 final class APIKeyQueryTest extends TestCase {

--- a/test/Query/CardQueryTest.php
+++ b/test/Query/CardQueryTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Query\CardQuery;
 
 final class CardQueryTest extends TestCase {

--- a/test/Query/ChargeQueryTest.php
+++ b/test/Query/ChargeQueryTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Query\ChargeQuery;
 
 final class ChargeQueryTest extends TestCase {

--- a/test/Query/EquipmentQueryTest.php
+++ b/test/Query/EquipmentQueryTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Query\EquipmentQuery;
 
 final class EquipmentQueryTest extends TestCase {

--- a/test/Query/LoggedEventQueryTest.php
+++ b/test/Query/LoggedEventQueryTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Query\LoggedEventQuery;
 
 final class LoggedEventQueryTest extends TestCase {

--- a/test/Query/PaymentQueryTest.php
+++ b/test/Query/PaymentQueryTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Query\PaymentQuery;
 
 final class PaymentQueryTest extends TestCase {

--- a/test/Query/UserQueryTest.php
+++ b/test/Query/UserQueryTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Query\UserQuery;
 
 final class UserQueryTest extends TestCase {

--- a/test/Transform/APIKeyTransformerTest.php
+++ b/test/Transform/APIKeyTransformerTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use PortalBox\Entity\APIKey;
 use Portalbox\Transform\APIKeyTransformer;
 

--- a/test/Transform/ChargeTransformerTest.php
+++ b/test/Transform/ChargeTransformerTest.php
@@ -3,9 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Config;
-
 use Portalbox\Entity\Charge;
 use Portalbox\Entity\ChargePolicy;
 use Portalbox\Entity\Equipment;
@@ -13,12 +11,10 @@ use Portalbox\Entity\EquipmentType;
 use Portalbox\Entity\Location;
 use Portalbox\Entity\Role;
 use Portalbox\Entity\User;
-
 use Portalbox\Model\EquipmentModel;
 use Portalbox\Model\EquipmentTypeModel;
 use Portalbox\Model\LocationModel;
 use Portalbox\Model\UserModel;
-
 use Portalbox\Transform\ChargeTransformer;
 
 final class ChargeTransformerTest extends TestCase {
@@ -61,7 +57,7 @@ final class ChargeTransformerTest extends TestCase {
 		$name = 'Tom Egan';
 		$email = 'tom@ficticious.tld';
 		$comment = 'Test Monkey';
-		$active = TRUE;
+		$active = true;
 
 		$user = (new User())
 			->set_name($name)
@@ -86,7 +82,7 @@ final class ChargeTransformerTest extends TestCase {
 		$model = new EquipmentTypeModel($config);
 
 		$name = 'Floodlight';
-		$requires_training = FALSE;
+		$requires_training = false;
 		$charge_policy_id = ChargePolicy::PER_USE;
 
 		$type = (new EquipmentType())
@@ -104,7 +100,7 @@ final class ChargeTransformerTest extends TestCase {
 		$name = '1000W Floodlight';
 		$mac_address = '0123456789AB';
 		$timeout = 0;
-		$is_in_service = TRUE;
+		$is_in_service = true;
 		$service_minutes = 500;
 
 		$equipment = (new Equipment())

--- a/test/Transform/EquipmentTransformerTest.php
+++ b/test/Transform/EquipmentTransformerTest.php
@@ -3,17 +3,13 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use PortalBox\Config;
-
 use PortalBox\Entity\ChargePolicy;
 use PortalBox\Entity\Equipment;
 use PortalBox\Entity\EquipmentType;
 use PortalBox\Entity\Location;
-
 use PortalBox\Model\EquipmentTypeModel;
 use PortalBox\Model\LocationModel;
-
 use Portalbox\Transform\EquipmentTransformer;
 
 final class EquipmentTransformerTest extends TestCase {
@@ -47,7 +43,7 @@ final class EquipmentTransformerTest extends TestCase {
 		$model = new EquipmentTypeModel($config);
 
 		$name = 'ceramics printer';
-		$requires_training = TRUE;
+		$requires_training = true;
 		$charge_rate = "0.01";
 		$charge_policy_id = ChargePolicy::PER_MINUTE;
 

--- a/test/Transform/EquipmentTypeTransformerTest.php
+++ b/test/Transform/EquipmentTypeTransformerTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Entity\ChargePolicy;
 use PortalBox\Entity\EquipmentType;
 use Portalbox\Transform\EquipmentTypeTransformer;
@@ -14,7 +13,7 @@ final class EquipmentTypeTransformerTest extends TestCase {
 
 		$id = 42;
 		$name = 'laser scalpel';
-		$requires_training = TRUE;
+		$requires_training = true;
 		$charge_rate = "2.50";
 		$charge_policy_id = ChargePolicy::PER_USE;
 		$charge_policy = ChargePolicy::name_for_policy($charge_policy_id);
@@ -45,7 +44,7 @@ final class EquipmentTypeTransformerTest extends TestCase {
 		$transformer = new EquipmentTypeTransformer();
 
 		$id = 42;
-		$requires_training = TRUE;
+		$requires_training = true;
 		$charge_rate = "2.50";
 		$charge_policy_id = ChargePolicy::PER_USE;
 		$allow_proxy = false;
@@ -88,7 +87,7 @@ final class EquipmentTypeTransformerTest extends TestCase {
 
 		$id = 42;
 		$name = 'laser scalpel';
-		$requires_training = TRUE;
+		$requires_training = true;
 		$charge_policy_id = ChargePolicy::PER_USE;
 		$allow_proxy = false;
 
@@ -109,7 +108,7 @@ final class EquipmentTypeTransformerTest extends TestCase {
 
 		$id = 42;
 		$name = 'laser scalpel';
-		$requires_training = TRUE;
+		$requires_training = true;
 		$charge_rate = "2.50";
 		$allow_proxy = false;
 
@@ -130,7 +129,7 @@ final class EquipmentTypeTransformerTest extends TestCase {
 
 		$id = 42;
 		$name = 'laser scalpel';
-		$requires_training = TRUE;
+		$requires_training = true;
 		$charge_rate = "2.50";
 		$charge_policy_id = ChargePolicy::PER_USE;
 
@@ -151,7 +150,7 @@ final class EquipmentTypeTransformerTest extends TestCase {
 
 		$id = 42;
 		$name = 'laser scalpel';
-		$requires_training = TRUE;
+		$requires_training = true;
 		$charge_rate = "2.50";
 		$charge_policy_id = ChargePolicy::PER_USE;
 		$charge_policy = ChargePolicy::name_for_policy($charge_policy_id);

--- a/test/Transform/LocationTransformerTest.php
+++ b/test/Transform/LocationTransformerTest.php
@@ -3,9 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use PortalBox\Entity\Location;
-
 use Portalbox\Transform\LocationTransformer;
 
 final class LocationTransformerTest extends TestCase {

--- a/test/Transform/LoggedEventTransformerTest.php
+++ b/test/Transform/LoggedEventTransformerTest.php
@@ -3,9 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use Portalbox\Config;
-
 use Portalbox\Entity\ChargePolicy;
 use Portalbox\Entity\Equipment;
 use Portalbox\Entity\EquipmentType;
@@ -14,12 +12,10 @@ use Portalbox\Entity\LoggedEvent;
 use Portalbox\Entity\LoggedEventType;
 use Portalbox\Entity\Role;
 use Portalbox\Entity\User;
-
 use Portalbox\Model\EquipmentModel;
 use Portalbox\Model\EquipmentTypeModel;
 use Portalbox\Model\LocationModel;
 use Portalbox\Model\UserModel;
-
 use Portalbox\Transform\LoggedEventTransformer;
 
 final class LoggedEventTransformerTest extends TestCase {
@@ -62,7 +58,7 @@ final class LoggedEventTransformerTest extends TestCase {
 		$name = 'Tom Egan';
 		$email = 'tom@ficticious.tld';
 		$comment = 'Test Monkey';
-		$active = TRUE;
+		$active = true;
 
 		$user = (new User())
 			->set_name($name)
@@ -87,7 +83,7 @@ final class LoggedEventTransformerTest extends TestCase {
 		$model = new EquipmentTypeModel($config);
 
 		$name = 'Floodlight';
-		$requires_training = FALSE;
+		$requires_training = false;
 		$event_policy_id = ChargePolicy::PER_USE;
 
 		$type = (new EquipmentType())
@@ -105,7 +101,7 @@ final class LoggedEventTransformerTest extends TestCase {
 		$name = '1000W Floodlight';
 		$mac_address = '0123456789AB';
 		$timeout = 0;
-		$is_in_service = TRUE;
+		$is_in_service = true;
 		$service_minutes = 500;
 
 		$equipment = (new Equipment())

--- a/test/Transform/PaymentTransformerTest.php
+++ b/test/Transform/PaymentTransformerTest.php
@@ -3,15 +3,11 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use PortalBox\Config;
-
 use PortalBox\Entity\Payment;
 use PortalBox\Entity\Role;
 use PortalBox\Entity\User;
-
 use PortalBox\Model\UserModel;
-
 use Portalbox\Transform\PaymentTransformer;
 
 final class PaymentTransformerTest extends TestCase {
@@ -36,7 +32,7 @@ final class PaymentTransformerTest extends TestCase {
 		$name = 'Tom Egan';
 		$email = 'tom@ficticious.tld';
 		$comment = 'Test Monkey';
-		$active = TRUE;
+		$active = true;
 
 		$user = (new User())
 			->set_name($name)

--- a/test/Transform/RoleTransformerTest.php
+++ b/test/Transform/RoleTransformerTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use PortalBox\Entity\Permission;
 use PortalBox\Entity\Role;
 use Portalbox\Transform\RoleTransformer;
@@ -14,7 +13,7 @@ final class RoleTransformerTest extends TestCase {
 
 		$id = 42;
 		$name = 'admin';
-		$is_system_role = TRUE;
+		$is_system_role = true;
 		$description = 'Users with this role have no restrictions.';
 		$permissions = [
 			Permission::LIST_OWN_EQUIPMENT_AUTHORIZATIONS,
@@ -45,7 +44,7 @@ final class RoleTransformerTest extends TestCase {
 		$transformer = new RoleTransformer();
 
 		$id = 42;
-		$is_system_role = TRUE;
+		$is_system_role = true;
 		$description = 'Users with this role have no restrictions.';
 		$permissions = [
 			Permission::LIST_OWN_EQUIPMENT_AUTHORIZATIONS,
@@ -68,7 +67,7 @@ final class RoleTransformerTest extends TestCase {
 
 		$id = 42;
 		$name = 'admin';
-		$is_system_role = TRUE;
+		$is_system_role = true;
 		$permissions = [
 			Permission::LIST_OWN_EQUIPMENT_AUTHORIZATIONS,
 			Permission::LIST_OWN_CARDS
@@ -90,7 +89,7 @@ final class RoleTransformerTest extends TestCase {
 
 		$id = 42;
 		$name = 'admin';
-		$is_system_role = TRUE;
+		$is_system_role = true;
 		$description = 'Users with this role have no restrictions.';
 
 		$data = [
@@ -109,7 +108,7 @@ final class RoleTransformerTest extends TestCase {
 
 		$id = 42;
 		$name = 'admin';
-		$is_system_role = TRUE;
+		$is_system_role = true;
 		$description = 'Users with this role have no restrictions.';
 		$permissions = [
 			Permission::LIST_OWN_EQUIPMENT_AUTHORIZATIONS,

--- a/test/Transform/UserTransformerTest.php
+++ b/test/Transform/UserTransformerTest.php
@@ -3,17 +3,13 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
 use PortalBox\Config;
-
 use Portalbox\Entity\ChargePolicy;
 use Portalbox\Entity\EquipmentType;
 use PortalBox\Entity\Permission;
 use PortalBox\Entity\Role;
 use PortalBox\Entity\User;
-
 use Portalbox\Model\EquipmentTypeModel;
-
 use Portalbox\Transform\UserTransformer;
 
 final class UserTransformerTest extends TestCase {
@@ -29,7 +25,7 @@ final class UserTransformerTest extends TestCase {
 		$model = new EquipmentTypeModel(Config::config());
 
 		$name = 'Floodlight';
-		$requires_training = FALSE;
+		$requires_training = false;
 		$charge_policy_id = ChargePolicy::NO_CHARGE;
 
 		$type = (new EquipmentType())
@@ -57,7 +53,7 @@ final class UserTransformerTest extends TestCase {
 		$name = 'Tom Egan';
 		$email = 'tom@ficticious.tld';
 		$comment = 'Test Monkey';
-		$is_active = TRUE;
+		$is_active = true;
 		$authorizations = [self::$type->id()];
 		$num_authorizations = count($authorizations);
 
@@ -94,7 +90,7 @@ final class UserTransformerTest extends TestCase {
 		$role_id = 3;	// default id of system defined admin role
 		$email = 'tom@ficticious.tld';
 		$comment = 'Test Monkey';
-		$is_active = TRUE;
+		$is_active = true;
 
 		$data = [
 			'id' => $id,
@@ -115,7 +111,7 @@ final class UserTransformerTest extends TestCase {
 		$name = 'Tom Egan';
 		$email = 'tom@ficticious.tld';
 		$comment = 'Test Monkey';
-		$is_active = TRUE;
+		$is_active = true;
 
 		$data = [
 			'id' => $id,
@@ -137,7 +133,7 @@ final class UserTransformerTest extends TestCase {
 		$name = 'Tom Egan';
 		$email = 'tom@ficticious.tld';
 		$comment = 'Test Monkey';
-		$is_active = TRUE;
+		$is_active = true;
 
 		$data = [
 			'id' => $id,
@@ -159,7 +155,7 @@ final class UserTransformerTest extends TestCase {
 		$role_id = 3;	// default id of system defined admin role
 		$name = 'Tom Egan';
 		$comment = 'Test Monkey';
-		$is_active = TRUE;
+		$is_active = true;
 
 		$data = [
 			'id' => $id,
@@ -202,7 +198,7 @@ final class UserTransformerTest extends TestCase {
 		$name = 'Tom Egan';
 		$email = 'tom@ficticious.tld';
 		$comment = 'Test Monkey';
-		$is_active = TRUE;
+		$is_active = true;
 		$authorizations = true;
 
 		$data = [
@@ -227,7 +223,7 @@ final class UserTransformerTest extends TestCase {
 		$name = 'Tom Egan';
 		$email = 'tom@ficticious.tld';
 		$comment = 'Test Monkey';
-		$is_active = TRUE;
+		$is_active = true;
 		$authorizations = [-1];
 
 		$data = [
@@ -249,7 +245,7 @@ final class UserTransformerTest extends TestCase {
 
 		$role_id = 3;	// default id of system defined admin role
 		$role_name = 'administrator';
-		$is_system_role = TRUE;
+		$is_system_role = true;
 		$description = 'Users with this role have no restrictions.';
 		$permissions = [
 			Permission::LIST_OWN_EQUIPMENT_AUTHORIZATIONS,
@@ -267,7 +263,7 @@ final class UserTransformerTest extends TestCase {
 		$name = 'Tom Egan';
 		$email = 'tom@ficticious.tld';
 		$comment = 'Test Monkey';
-		$is_active = TRUE;
+		$is_active = true;
 		$authorizations = [self::$type->id()];
 
 		$user = (new User())


### PR DESCRIPTION
This PR if accept brings us close to adopting the PSR-12 coding standard for writing PHP code with a few notable exceptions:

- I used snake case variable and method names following the PHP contributions code guidelines originally. It will take more work to get to camelCase as recommended by PSR-12. I intend to move this way eventually but probably not a top priority.
- I'm using "cuddled braces" which means we'll have one brace formatting style across PHP and Javascript should we adopt the ESlint baseline for Javascript which just makes things a bit easier
- I have used tabs because it leaves the tab width decision up to individual contributor's editor settings. Who am I to say if 2 or 4 or 8 space wide indents are more readable for someone after all.