### PR TITLE
cleanup: standardize on the short array declaration

### DIFF
--- a/src/Entity/Role.php
+++ b/src/Entity/Role.php
@@ -69,7 +69,7 @@ class Role {
 	 */
 	public function permissions(): array {
 		if (null === $this->permissions) {
-			return array();
+			return [];
 		}
 		return $this->permissions;
 	}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -136,7 +136,7 @@ class User {
 	/** Get the authorizations for this user */
 	public function authorizations(): array {
 		if (null === $this->authorizations) {
-			return array();
+			return [];
 		}
 		return $this->authorizations;
 	}

--- a/src/Model/APIKeyModel.php
+++ b/src/Model/APIKeyModel.php
@@ -132,7 +132,7 @@ class APIKeyModel extends AbstractModel {
 		$connection = $this->configuration()->readonly_db_connection();
 		$sql = 'SELECT id, name, token FROM api_keys';
 
-		$where_clause_fragments = array();
+		$where_clause_fragments = [];
 		if (null !== $query->token()) {
 			$where_clause_fragments[] = 'token = :token';
 		}
@@ -166,7 +166,7 @@ class APIKeyModel extends AbstractModel {
 	}
 
 	private function buildAPIKeysFromArrays(array $data): array {
-		$keys = array();
+		$keys = [];
 
 		foreach ($data as $datum) {
 			$keys[] = $this->buildAPIKeyFromArray($datum);

--- a/src/Model/CardModel.php
+++ b/src/Model/CardModel.php
@@ -172,8 +172,8 @@ class CardModel extends AbstractModel {
 
 		$sql = 'SELECT c.id, c.type_id, uxc.user_id, etxc.equipment_type_id FROM cards AS c LEFT JOIN users_x_cards AS uxc ON c.id = uxc.card_id LEFT JOIN equipment_type_x_cards AS etxc ON c.id = etxc.card_id';
 
-		$where_clause_fragments = array();
-		$parameters = array();
+		$where_clause_fragments = [];
+		$parameters = [];
 		if (null !== $query && null !== $query->equipment_type_id()) {
 			$where_clause_fragments[] = 'etxc.equipment_type_id = :equipment_type_id';
 			$parameters[':equipment_type_id'] = $query->equipment_type_id();

--- a/src/Model/CardTypeModel.php
+++ b/src/Model/CardTypeModel.php
@@ -29,7 +29,7 @@ class CardTypeModel extends AbstractModel {
 	}
 
 	private function buildCardTypesFromArrays(array $data): array {
-		$card_types = array();
+		$card_types = [];
 
 		foreach ($data as $datum) {
 			$card_types[] = $this->buildCardTypesFromArray($datum);

--- a/src/Model/ChargeModel.php
+++ b/src/Model/ChargeModel.php
@@ -139,8 +139,8 @@ class ChargeModel extends AbstractModel {
 		INNER JOIN users AS u on u.id = c.user_id
 		EOQ;
 
-		$where_clause_fragments = array();
-		$parameters = array();
+		$where_clause_fragments = [];
+		$parameters = [];
 
 		if (null !== $query->equipment_id()) {
 			$where_clause_fragments[] = 'c.equipment_id = :equipment_id';

--- a/src/Model/EquipmentModel.php
+++ b/src/Model/EquipmentModel.php
@@ -168,8 +168,8 @@ class EquipmentModel extends AbstractModel {
 		LEFT JOIN in_use AS iu ON e.id = iu.equipment_id
 		EOQ;
 
-		$where_clause_fragments = array();
-		$parameters = array();
+		$where_clause_fragments = [];
+		$parameters = [];
 		if (null !== $query->location_id()) {
 			$where_clause_fragments[] = 'l.id = :location';
 			$parameters[':location'] = $query->location_id();

--- a/src/Model/EquipmentTypeModel.php
+++ b/src/Model/EquipmentTypeModel.php
@@ -141,7 +141,7 @@ class EquipmentTypeModel extends AbstractModel {
 	}
 
 	private function buildEquipmentTypesFromArrays(array $data): array {
-		$locations = array();
+		$locations = [];
 
 		foreach ($data as $datum) {
 			$locations[] = $this->buildEquipmentTypeFromArray($datum);

--- a/src/Model/LocationModel.php
+++ b/src/Model/LocationModel.php
@@ -130,7 +130,7 @@ class LocationModel extends AbstractModel {
 	}
 
 	private function buildLocationsFromArrays(array $data): array {
-		$locations = array();
+		$locations = [];
 
 		foreach ($data as $datum) {
 			$locations[] = $this->buildLocationFromArray($datum);

--- a/src/Model/LoggedEventModel.php
+++ b/src/Model/LoggedEventModel.php
@@ -97,8 +97,8 @@ class LoggedEventModel extends AbstractModel {
 		LEFT JOIN users AS u ON u.id = uxc.user_id
 		EOQ;
 
-		$where_clause_fragments = array();
-		$parameters = array();
+		$where_clause_fragments = [];
+		$parameters = [];
 		if ($query->equipment_id()) {
 			$where_clause_fragments[] = 'el.equipment_id = :equipment_id';
 			$parameters[':equipment_id'] = $query->equipment_id();
@@ -163,7 +163,7 @@ class LoggedEventModel extends AbstractModel {
 	}
 
 	private function buildLoggedEventsFromArray(array $data): array {
-		$log = array();
+		$log = [];
 
 		foreach ($data as $datum) {
 			$log[] = $this->buildLoggedEventFromArray($datum);

--- a/src/Model/PaymentModel.php
+++ b/src/Model/PaymentModel.php
@@ -119,8 +119,8 @@ class PaymentModel extends AbstractModel {
 
 		$connection = $this->configuration()->readonly_db_connection();
 		$sql = 'SELECT id, user_id, amount, time FROM payments';
-		$where_clause_fragments = array();
-		$parameters = array();
+		$where_clause_fragments = [];
+		$parameters = [];
 		if (null !== $query->user_id()) {
 			$where_clause_fragments[] = 'user_id = :user_id';
 			$parameters[':user_id'] = $query->user_id();
@@ -166,7 +166,7 @@ class PaymentModel extends AbstractModel {
 	}
 
 	private function buildPaymentsFromArrays(array $data): array {
-		$payments = array();
+		$payments = [];
 
 		foreach ($data as $datum) {
 			$payments[] = $this->buildPaymentFromArray($datum);

--- a/src/Model/RoleModel.php
+++ b/src/Model/RoleModel.php
@@ -221,7 +221,7 @@ class RoleModel extends AbstractModel {
 	}
 
 	private function buildRolesFromArrays(array $data): array {
-		$roles = array();
+		$roles = [];
 
 		foreach ($data as $datum) {
 			$roles[] = $this->buildRoleFromArray($datum);

--- a/src/Model/UserModel.php
+++ b/src/Model/UserModel.php
@@ -216,8 +216,8 @@ class UserModel extends AbstractModel {
 
 		$connection = $this->configuration()->readonly_db_connection();
 		$sql = 'SELECT u.id, u.name, u.email, u.comment, u.is_active, u.role_id, r.name AS role, u.pin FROM users AS u INNER JOIN roles AS r ON u.role_id = r.id';
-		$where_clause_fragments = array();
-		$parameters = array();
+		$where_clause_fragments = [];
+		$parameters = [];
 		$modifier = "";
 
 		if (null !== $query->include_inactive()) {


### PR DESCRIPTION
This PR if accepted cleans up code style by standardizing on the short array declaration syntax `[]` instead of the old PHP `array()`.