### PR TITLE
chore: use rector to automatically update php to baseline

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,12 @@
     "type": "project",
     "require-dev": {
         "phpunit/phpunit": "^9.6",
-        "squizlabs/php_codesniffer": "^3.11"
+        "squizlabs/php_codesniffer": "^3.11",
+        "rector/rector": "^2.1"
     },
     "license": "apache2.0",
     "require": {
+        "php": ">=7.4",
         "ext-pdo": "*",
         "ext-json": "*"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "66d4ed4e281f6cdb5bcaca085c3b34a9",
+    "content-hash": "966faed068f5f238d3888d69f5843ee6",
     "packages": [],
     "packages-dev": [
         {
@@ -312,6 +312,64 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.22",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "41600c8379eb5aee63e9413fe9e97273e25d57e4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/41600c8379eb5aee63e9413fe9e97273e25d57e4",
+                "reference": "41600c8379eb5aee63e9413fe9e97273e25d57e4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-04T19:17:37+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -734,6 +792,66 @@
                 }
             ],
             "time": "2024-12-05T13:48:26+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "40a71441dd73fa150a66102f5ca1364c44fc8fff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/40a71441dd73fa150a66102f5ca1364c44fc8fff",
+                "reference": "40a71441dd73fa150a66102f5ca1364c44fc8fff",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.1.18"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/2.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-07-17T19:30:06+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/public/api',
+        __DIR__ . '/src',
+        __DIR__ . '/test',
+    ])
+    ->withPhpSets()
+    ->withTypeCoverageLevel(0)
+    ->withDeadCodeLevel(0)
+    ->withCodeQualityLevel(0);

--- a/src/Entity/Equipment.php
+++ b/src/Entity/Equipment.php
@@ -110,7 +110,7 @@ class Equipment {
 			throw new InvalidArgumentException('The specified MAC Address must be valid');
 		}
 
-		$this->mac_address = strtolower(str_replace(array('-', ':'), '', $mac_address));
+		$this->mac_address = strtolower(str_replace(['-', ':'], '', $mac_address));
 		return $this;
 	}
 

--- a/src/Model/APIKeyModel.php
+++ b/src/Model/APIKeyModel.php
@@ -138,7 +138,7 @@ class APIKeyModel extends AbstractModel {
 		}
 		if (0 < count($where_clause_fragments)) {
 			$sql .= ' WHERE ';
-			$sql .= join(' AND ', $where_clause_fragments);
+			$sql .= implode(' AND ', $where_clause_fragments);
 		}
 
 		$statement = $connection->prepare($sql);

--- a/src/Model/AbstractModel.php
+++ b/src/Model/AbstractModel.php
@@ -9,11 +9,9 @@ use Portalbox\Config;
  */
 class AbstractModel {
 	/**
-	 * The configuration to use
-	 *
-	 * @var Config
+	 * The configuration to use to connect to the database
 	 */
-	private $configuration;
+	private Config $configuration;
 
 	/**
 	 * @param Config configuration - the configuration to use
@@ -23,18 +21,14 @@ class AbstractModel {
 	}
 
 	/**
-	 * Get the configuration to use
-	 *
-	 * @return Config - the configuration to use
+	 * Get the configuration to use to connect to the database
 	 */
 	public function configuration(): Config {
 		return $this->configuration;
 	}
 
 	/**
-	 * Set the configuration to use
-	 *
-	 * @param Config configuration - the configuration to use
+	 * Set the configuration to use to connect to the database
 	 */
 	public function set_configuration(Config $configuration): void {
 		$this->configuration = $configuration;

--- a/src/Model/CardModel.php
+++ b/src/Model/CardModel.php
@@ -10,7 +10,6 @@ use Portalbox\Entity\TrainingCard;
 use Portalbox\Entity\UserCard;
 use Portalbox\Exception\DatabaseException;
 use Portalbox\Query\CardQuery;
-use Portalbox\Query\UserQuery;
 use Exception;
 use PDO;
 
@@ -91,7 +90,7 @@ class CardModel extends AbstractModel {
 		$query->bindValue(':id', $id);	//BIGINT
 		if ($query->execute()) {
 			if ($data = $query->fetch(PDO::FETCH_ASSOC)) {
-				return $this->buildCardsFromArrays(array($data))[0];
+				return $this->buildCardsFromArrays([$data])[0];
 			} else {
 				return null;
 			}
@@ -188,7 +187,7 @@ class CardModel extends AbstractModel {
 		}
 		if (0 < count($where_clause_fragments)) {
 			$sql .= ' WHERE ';
-			$sql .= join(' AND ', $where_clause_fragments);
+			$sql .= implode(' AND ', $where_clause_fragments);
 		}
 		$statement = $connection->prepare($sql);
 		// run search
@@ -218,9 +217,7 @@ class CardModel extends AbstractModel {
 				$equipment_type_id = $data['equipment_type_id'];
 				$equipment_type = array_filter(
 					$equipment_types,
-					function ($e) use ($equipment_type_id) {
-						return $e->id() == $equipment_type_id;
-					}
+					fn($e) => $e->id() == $equipment_type_id
 				);
 
 				$equipment_type = array_pop($equipment_type);
@@ -234,9 +231,7 @@ class CardModel extends AbstractModel {
 				$user_id = $data['user_id'];
 				$user = array_filter(
 					$users,
-					function ($e) use ($user_id) {
-						return $e->id() == $user_id;
-					}
+					fn($e) => $e->id() == $user_id
 				);
 
 				$user = array_pop($user);
@@ -260,10 +255,8 @@ class CardModel extends AbstractModel {
 		$u_model = new UserModel($this->configuration());
 		$r_model = new RoleModel($this->configuration());
 
-		$u_query = new UserQuery();
-
 		$equipment_types = $e_model->search();
-		$users = $u_model->search($u_query);
+		$users = $u_model->search();
 		$roles = $r_model->search();
 
 		foreach ($users as $user) {
@@ -271,9 +264,7 @@ class CardModel extends AbstractModel {
 
 			$role = array_filter(
 				$roles,
-				function ($e) use ($r_id) {
-					return $e->id() == $r_id;
-				}
+				fn($e) => $e->id() == $r_id
 			);
 			$user->set_role(array_pop($role));
 		}

--- a/src/Model/CardTypeModel.php
+++ b/src/Model/CardTypeModel.php
@@ -19,7 +19,7 @@ class CardTypeModel extends AbstractModel {
 				return null;
 			}
 		} else {
-			throw new DatabaseExcpetion($connection->errorInfo()[2]);
+			throw new DatabaseException($connection->errorInfo()[2]);
 		}
 	}
 

--- a/src/Model/ChargeModel.php
+++ b/src/Model/ChargeModel.php
@@ -161,7 +161,7 @@ class ChargeModel extends AbstractModel {
 		}
 		if (0 < count($where_clause_fragments)) {
 			$sql .= ' WHERE ';
-			$sql .= join(' AND ', $where_clause_fragments);
+			$sql .= implode(' AND ', $where_clause_fragments);
 		}
 		$sql .= ' ORDER BY time DESC';
 
@@ -198,7 +198,6 @@ class ChargeModel extends AbstractModel {
 	}
 
 	private function buildChargesFromArrays(array $data): array {
-
 		$charges = [];
 		$machines = [];
 		$users = [];
@@ -208,41 +207,31 @@ class ChargeModel extends AbstractModel {
 
 		$e_query = new EquipmentQuery();
 		$e_query->set_include_out_of_service(true);
-		$u_query = new UserQuery();
-		$u_query->set_include_inactive(true);
+		$u_query = (new UserQuery())
+			->set_include_inactive(true);
 
 		$machines = $e_model->search($e_query);
 		$users = $u_model->search($u_query);
 
 		foreach ($data as $datum) {
 			$charges[] = $this->buildChargeFromArray($datum);
-			// echo print_r($datum, true) . "<br>";
 		}
-		// echo count($charges). "<br>";
-		// $x = 0;
+
 		foreach ($charges as $charge) {
-			// echo $x . ":";
-			// echo $charge->equipment_id() . "<br>";
-			// $x += 1;
 			$e_id = $charge->equipment_id();
 
 			$machine = array_filter(
 				$machines,
-				function ($e) use ($e_id) {
-					return $e->id() == $e_id;
-				}
+				fn($e) => $e->id() == $e_id
 			);
 
-			// echo array_pop($machine)->id();
 			$charge->set_equipment(array_pop($machine));
 
 			$u_id = $charge->user_id();
 
 			$user = array_filter(
 				$users,
-				function ($e) use ($u_id) {
-					return $e->id() == $u_id;
-				}
+				fn($e) => $e->id() == $u_id
 			);
 
 			$charge->set_user(array_pop($user));

--- a/src/Model/EquipmentModel.php
+++ b/src/Model/EquipmentModel.php
@@ -189,7 +189,7 @@ class EquipmentModel extends AbstractModel {
 
 		if (0 < count($where_clause_fragments)) {
 			$sql .= ' WHERE ';
-			$sql .= join(' AND ', $where_clause_fragments);
+			$sql .= implode(' AND ', $where_clause_fragments);
 		}
 		$sql .= ' ORDER BY l.name, t.name, e.name';
 

--- a/src/Model/LoggedEventModel.php
+++ b/src/Model/LoggedEventModel.php
@@ -125,7 +125,7 @@ class LoggedEventModel extends AbstractModel {
 		}
 		if (0 < count($where_clause_fragments)) {
 			$sql .= ' WHERE ';
-			$sql .= join(' AND ', $where_clause_fragments);
+			$sql .= implode(' AND ', $where_clause_fragments);
 		}
 		$sql .= ' ORDER BY el.time DESC, el.id DESC';
 

--- a/src/Model/PaymentModel.php
+++ b/src/Model/PaymentModel.php
@@ -135,7 +135,7 @@ class PaymentModel extends AbstractModel {
 		}
 		if (0 < count($where_clause_fragments)) {
 			$sql .= ' WHERE ';
-			$sql .= join(' AND ', $where_clause_fragments);
+			$sql .= implode(' AND ', $where_clause_fragments);
 		}
 		$sql .= ' ORDER BY time DESC';
 

--- a/src/Model/UserModel.php
+++ b/src/Model/UserModel.php
@@ -244,7 +244,7 @@ class UserModel extends AbstractModel {
 			}
 			if (0 < count($where_clause_fragments)) {
 				$sql .= ' WHERE ';
-				$sql .= join(' AND ', $where_clause_fragments);
+				$sql .= implode(' AND ', $where_clause_fragments);
 			}
 		}
 

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -1,11 +1,11 @@
 <?php
 
-spl_autoload_register(function ($class_name) {
+spl_autoload_register(function ($class_name): void {
 	$fragments = explode('\\', $class_name);
 
 	if (0 < count($fragments) && 'Portalbox' == $fragments[0]) {
 		$fragments[0] = __DIR__;
 
-		require join(DIRECTORY_SEPARATOR, $fragments) . '.php';
+		require implode(DIRECTORY_SEPARATOR, $fragments) . '.php';
 	}
 });

--- a/test/Entity/RoleTest.php
+++ b/test/Entity/RoleTest.php
@@ -15,10 +15,10 @@ final class RoleTest extends TestCase {
 		$name = 'admin';
 		$is_system_role = true;
 		$description = 'Users with this role have no restrictions.';
-		$permissions = array(
+		$permissions = [
 			Permission::READ_API_KEY,
 			Permission::READ_CARD
-		);
+		];
 		$permissions_count = 2;
 
 		$role = (new Role())
@@ -39,11 +39,11 @@ final class RoleTest extends TestCase {
 	}
 
 	public function testSetInvalidPermissionListTriggersException(): void {
-		$permissions = array(
+		$permissions = [
 			Permission::READ_API_KEY,
 			Permission::READ_CARD,
 			-1
-		);
+		];
 
 		$this->expectException(InvalidArgumentException::class);
 

--- a/test/Entity/UserTest.php
+++ b/test/Entity/UserTest.php
@@ -15,10 +15,10 @@ final class UserTest extends TestCase {
 		$comment = 'Test Monkey';
 		$active = false;
 		$pin = '1234';
-		$authorizations = array(
+		$authorizations = [
 			34,
 			23
-		);
+		];
 		$num_authorizations = count($authorizations);
 
 		$user = (new User())

--- a/test/Model/CardModelTest.php
+++ b/test/Model/CardModelTest.php
@@ -283,18 +283,14 @@ final class CardModelTest extends TestCase {
 
 		$shutdown_card = $model->create($card);
 
-		$cards = array_map(function ($card) {
-			return $card->id();
-		}, $model->search());
+		$cards = array_map(fn($card) => $card->id(), $model->search());
 		self::assertContains($user_card_1->id(), $cards);
 		self::assertContains($user_card_2->id(), $cards);
 		self::assertContains($training_card->id(), $cards);
 		self::assertContains($shutdown_card->id(), $cards);
 
 		$query = new CardQuery();
-		$cards = array_map(function ($card) {
-			return $card->id();
-		}, $model->search($query));
+		$cards = array_map(fn($card) => $card->id(), $model->search($query));
 		self::assertContains($user_card_1->id(), $cards);
 		self::assertContains($user_card_2->id(), $cards);
 		self::assertContains($training_card->id(), $cards);
@@ -302,9 +298,7 @@ final class CardModelTest extends TestCase {
 
 		$query = (new CardQuery())
 			->set_user_id($user_id);
-		$cards = array_map(function ($card) {
-			return $card->id();
-		}, $model->search($query));
+		$cards = array_map(fn($card) => $card->id(), $model->search($query));
 		self::assertContains($user_card_1->id(), $cards);
 		self::assertContains($user_card_2->id(), $cards);
 		self::assertNotContains($training_card->id(), $cards);
@@ -312,9 +306,7 @@ final class CardModelTest extends TestCase {
 
 		$query = (new CardQuery())
 			->set_equipment_type_id($equipment_type_id);
-		$cards = array_map(function ($card) {
-			return $card->id();
-		}, $model->search($query));
+		$cards = array_map(fn($card) => $card->id(), $model->search($query));
 		self::assertNotContains($user_card_1->id(), $cards);
 		self::assertNotContains($user_card_2->id(), $cards);
 		self::assertContains($training_card->id(), $cards);

--- a/test/Model/RoleModelTest.php
+++ b/test/Model/RoleModelTest.php
@@ -22,7 +22,7 @@ final class RoleModelTest extends TestCase {
 			->set_name($name)
 			->set_is_system_role($is_system_role)
 			->set_description($description)
-			->set_permissions(array(Permission::CREATE_API_KEY));
+			->set_permissions([Permission::CREATE_API_KEY]);
 
 		$role_as_created = $model->create($role);
 


### PR DESCRIPTION
This PR if accepted use [rector](https://github.com/rectorphp/rector) to adopt code compatibility practices recommended by the PHP development team for our target PHP version; currently PHP 7.4. My hope is that we can use `rector` to automate bringing the project inline with PHP 8.x recommendations in the future.