### PR TITLE
chore: switch from htmlspecialchars to strip_tags

### DIFF
--- a/src/Transform/APIKeyTransformer.php
+++ b/src/Transform/APIKeyTransformer.php
@@ -23,7 +23,7 @@ class APIKeyTransformer implements InputTransformer, OutputTransformer {
 		}
 
 		return (new APIKey())
-			->set_name(htmlspecialchars($data['name']));
+			->set_name(strip_tags($data['name']));
 	}
 
 	/**

--- a/src/Transform/EquipmentTransformer.php
+++ b/src/Transform/EquipmentTransformer.php
@@ -57,7 +57,7 @@ class EquipmentTransformer implements InputTransformer, OutputTransformer {
 		}
 
 		return (new Equipment())
-			->set_name(htmlspecialchars($data['name']))
+			->set_name(strip_tags($data['name']))
 			->set_type($type)
 			->set_location($location)
 			->set_mac_address($data['mac_address'])

--- a/src/Transform/EquipmentTypeTransformer.php
+++ b/src/Transform/EquipmentTypeTransformer.php
@@ -40,7 +40,7 @@ class EquipmentTypeTransformer implements InputTransformer, OutputTransformer {
 
 
 		return (new EquipmentType())
-			->set_name(htmlspecialchars($data['name']))
+			->set_name(strip_tags($data['name']))
 			->set_requires_training($data['requires_training'])
 			->set_charge_rate($data['charge_rate'])
 			->set_charge_policy_id($data['charge_policy_id'])

--- a/src/Transform/LocationTransformer.php
+++ b/src/Transform/LocationTransformer.php
@@ -22,7 +22,7 @@ class LocationTransformer implements InputTransformer, OutputTransformer {
 			throw new InvalidArgumentException('\'name\' is a required field');
 		}
 
-		return (new Location())->set_name(htmlspecialchars($data['name']));
+		return (new Location())->set_name(strip_tags($data['name']));
 	}
 
 	/**

--- a/src/Transform/RoleTransformer.php
+++ b/src/Transform/RoleTransformer.php
@@ -29,8 +29,8 @@ class RoleTransformer implements InputTransformer, OutputTransformer {
 		}
 
 		return (new Role())
-			->set_name(htmlspecialchars($data['name']))
-			->set_description(htmlspecialchars($data['description']))
+			->set_name(strip_tags($data['name']))
+			->set_description(strip_tags($data['description']))
 			->set_is_system_role(false)	// hard coded as a business rule
 			->set_permissions($data['permissions']);
 	}

--- a/src/Transform/UserTransformer.php
+++ b/src/Transform/UserTransformer.php
@@ -41,8 +41,8 @@ class UserTransformer implements InputTransformer, OutputTransformer {
 		}
 
 		$user = (new User())
-					->set_name(htmlspecialchars($data['name']))
-					->set_email(htmlspecialchars($data['email']))
+					->set_name(strip_tags($data['name']))
+					->set_email(strip_tags($data['email']))
 					->set_is_active($data['is_active'])
 					->set_role($role);
 

--- a/test/Transform/LocationTransformerTest.php
+++ b/test/Transform/LocationTransformerTest.php
@@ -25,7 +25,7 @@ final class LocationTransformerTest extends TestCase {
 
 		self::assertNotNull($location);
 		self::assertNull($location->id());
-		self::assertEquals(htmlspecialchars($name), $location->name());
+		self::assertEquals(strip_tags($name), $location->name());
 	}
 
 	public function testDeserializeInvalidDataUserID(): void {


### PR DESCRIPTION
Years ago I used the php function `htmlspecialchars` to sanitize strings in order to prevent XSS attacks. This however usually leads to garbled values like `&#039;` when someone wants to use a single quote. This PR if accepted changes to a more aggressive sanitization method `strip_tags` which removes all html markup from user input but allows users to use single quotes.