### PR TITLE
feature: extract exception handling into procedure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 /public/js/.bin/
 /public/js/file-saver/
 /public/js/hellojs/
-/public/js/moostaka/
 /public/js/mustache/
 /public/js/.yarn-integrity
 

--- a/public/api/api-keys.php
+++ b/public/api/api-keys.php
@@ -5,6 +5,7 @@ require '../../src/autoload.php';
 use Portalbox\Config;
 use Portalbox\ResponseHandler;
 use Portalbox\Entity\Permission;
+use Portalbox\Exception\NotFoundException;
 use Portalbox\Model\APIKeyModel;
 use Portalbox\Query\APIKeyQuery;
 use Portalbox\Session\Session;
@@ -12,32 +13,26 @@ use Portalbox\Transform\APIKeyTransformer;
 
 $session = new Session();
 
-// switch on the request method
-switch($_SERVER['REQUEST_METHOD']) {
-	case 'GET':		// List/Read
-		if(isset($_GET['id']) && !empty($_GET['id'])) {	// Read
-			// check authorization
-			$session->require_authorization(Permission::READ_API_KEY);
+try {
+	switch($_SERVER['REQUEST_METHOD']) {
+		case 'GET':		// List/Read
+			if(isset($_GET['id']) && !empty($_GET['id'])) {	// Read
+				// check authorization
+				$session->require_authorization(Permission::READ_API_KEY);
 
-			try {
 				$model = new APIKeyModel(Config::config());
 				$key = $model->read($_GET['id']);
-				if($key) {
-					$transformer = new APIKeyTransformer();
-					ResponseHandler::render($key, $transformer);
-				} else {
-					http_response_code(404);
-					die('We have no record of that API key');
-				}
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
-			}
-		} else { // List
-			// check authorization
-			$session->require_authorization(Permission::LIST_API_KEYS);
 
-			try {
+				if(!$key) {
+					throw new NotFoundException('We have no record of that API key');
+				}
+
+				$transformer = new APIKeyTransformer();
+				ResponseHandler::render($key, $transformer);
+			} else { // List
+				// check authorization
+				$session->require_authorization(Permission::LIST_API_KEYS);
+
 				$model = new APIKeyModel(Config::config());
 				$query = new APIKeyQuery();
 				if(isset($_GET['token']) && !empty($_GET['token'])) {
@@ -46,94 +41,71 @@ switch($_SERVER['REQUEST_METHOD']) {
 				$keys = $model->search($query);
 				$transformer = new APIKeyTransformer();
 				ResponseHandler::render($keys, $transformer);
-			} catch(Exception $e) {
-				http_response_code(500);
-				die($e->getMessage());
-				die('We experienced issues communicating with the database');
 			}
-		}
-		break;
-	case 'POST':	// Update
-		// validate that we have an oid
-		if(!isset($_GET['id']) || empty($_GET['id'])) {
-			http_response_code(400);
-			die('You must specify the API key to modify via the id param');
-		}
-
-		// check authorization
-		$session->require_authorization(Permission::MODIFY_API_KEY);
-
-		$data = json_decode(file_get_contents('php://input'), TRUE);
-		if(NULL !== $data) {
-			try {
-				$transformer = new APIKeyTransformer();
-				$key = $transformer->deserialize($data);
-				$key->set_id($_GET['id']);
-				$model = new APIKeyModel(Config::config());
-				$key = $model->update($key);
-				ResponseHandler::render($key, $transformer);
-			} catch(InvalidArgumentException $iae) {
-				http_response_code(400);
-				die($iae->getMessage());
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
+			break;
+		case 'POST':	// Update
+			// validate that we have an oid
+			if(!isset($_GET['id']) || empty($_GET['id'])) {
+				throw new InvalidArgumentException('You must specify the API key to modify via the id param');
 			}
-		} else {
-			http_response_code(400);
-			die(json_last_error_msg());
-		}
-		break;
-	case 'PUT':		// Create
-		// check authorization
-		$session->require_authorization(Permission::CREATE_API_KEY);
 
-		$data = json_decode(file_get_contents('php://input'), TRUE);
-		if(NULL !== $data) {
-			try {
-				$transformer = new APIKeyTransformer();
-				$key = $transformer->deserialize($data);
-				$model = new APIKeyModel(Config::config());
-				$key = $model->create($key);
-				ResponseHandler::render($key, $transformer);
-			} catch(InvalidArgumentException $iae) {
-				http_response_code(400);
-				die($iae->getMessage());
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
+			// check authorization
+			$session->require_authorization(Permission::MODIFY_API_KEY);
+
+			$data = json_decode(file_get_contents('php://input'), TRUE);
+			if($data === null) {
+				throw new InvalidArgumentException(json_last_error_msg());
 			}
-		} else {
-			http_response_code(400);
-			die(json_last_error_msg());
-		}
-		break;
-	case 'DELETE':	// Delete
-		// validate that we have an oid
-		if(!isset($_GET['id']) || empty($_GET['id'])) {
-			http_response_code(400);
-			die('You must specify the api key to delete via the id param');
-		}
 
-		// check authorization
-		$session->require_authorization(Permission::DELETE_API_KEY);
+			$transformer = new APIKeyTransformer();
+			$key = $transformer->deserialize($data);
+			$key->set_id($_GET['id']);
+			$model = new APIKeyModel(Config::config());
+			$key = $model->update($key);
+			ResponseHandler::render($key, $transformer);
+			break;
+		case 'PUT':		// Create
+			// check authorization
+			$session->require_authorization(Permission::CREATE_API_KEY);
 
-		try {
+			$data = json_decode(file_get_contents('php://input'), TRUE);
+			if($data === null) {
+				throw new InvalidArgumentException(json_last_error_msg());
+			}
+
+			$transformer = new APIKeyTransformer();
+			$key = $transformer->deserialize($data);
+			$model = new APIKeyModel(Config::config());
+			$key = $model->create($key);
+			ResponseHandler::render($key, $transformer);
+			break;
+		case 'DELETE':	// Delete
+			// validate that we have an oid
+			if(!isset($_GET['id']) || empty($_GET['id'])) {
+				throw new InvalidArgumentException('You must specify the api key to delete via the id param');
+			}
+
+			// check authorization
+			$session->require_authorization(Permission::DELETE_API_KEY);
+
 			$model = new APIKeyModel(Config::config());
 			$key = $model->delete($_GET['id']);
-			if($key) {
-				$transformer = new APIKeyTransformer();
-				ResponseHandler::render($key, $transformer);
-			} else {
-				http_response_code(404);
-				die('We have no record of that API key');
+			if(!$key) {
+				throw new NotFoundException('We have no record of that API key');
 			}
-		} catch(Exception $e) {
-			http_response_code(500);
-			die('We experienced issues communicating with the database');
-		}
-		break;
-	default:
-		http_response_code(405);
-		die('We were unable to understand your request.');
+
+			$transformer = new APIKeyTransformer();
+			ResponseHandler::render($key, $transformer);
+			break;
+		default:
+			http_response_code(405);
+			die('We were unable to understand your request.');
+	}
+} catch(Throwable $t) {
+	ResponseHandler::setResponseCode($t);
+	$message = $t->getMessage();
+	if (empty($message)) {
+		$message = ResponseHandler::GENERIC_ERROR_MESSAGE;
+	}
+	die($message);
 }

--- a/public/api/card-types.php
+++ b/public/api/card-types.php
@@ -11,19 +11,22 @@ use Portalbox\Transform\CardTypeTransformer;
 
 $session = new Session();
 
-//switch on the request method
-switch($_SERVER['REQUEST_METHOD']) {
-    case 'GET':     // List
-        $session->require_authorization(Permission::LIST_CARD_TYPES);
+try {
+	switch($_SERVER['REQUEST_METHOD']) {
+		case 'GET':     // List
+			$session->require_authorization(Permission::LIST_CARD_TYPES);
 
-        try {
-            $model = new CardTypeModel(Config::config());
-            $card_types = $model->search();
-            $transformer = new CardTypeTransformer();
-            ResponseHandler::render($card_types, $transformer);
-        } catch(Exception $e) {
-            http_response_code(500);
-            die('We experienced issues communicating with the database');
-        }
-    break;
+			$model = new CardTypeModel(Config::config());
+			$card_types = $model->search();
+			$transformer = new CardTypeTransformer();
+			ResponseHandler::render($card_types, $transformer);
+		break;
+	}
+} catch(Throwable $t) {
+	ResponseHandler::setResponseCode($t);
+	$message = $t->getMessage();
+	if (empty($message)) {
+		$message = ResponseHandler::GENERIC_ERROR_MESSAGE;
+	}
+	die($message);
 }

--- a/public/api/cards.php
+++ b/public/api/cards.php
@@ -5,6 +5,7 @@ require '../../src/autoload.php';
 use Portalbox\Config;
 use Portalbox\ResponseHandler;
 use Portalbox\Entity\Permission;
+use Portalbox\Exception\NotFoundException;
 use Portalbox\Model\CardModel;
 use Portalbox\Query\CardQuery;
 use Portalbox\Session\Session;
@@ -12,55 +13,43 @@ use Portalbox\Transform\CardTransformer;
 
 $session = new Session();
 
-// switch on the request method
-switch($_SERVER['REQUEST_METHOD']) {
-	case 'GET':		// List/Read
-		if(isset($_GET['id']) && !empty($_GET['id'])) {	// Read
-			$session->require_authorization(Permission::READ_CARD);
+try {
+	switch($_SERVER['REQUEST_METHOD']) {
+		case 'GET':		// List/Read
+			if(isset($_GET['id']) && !empty($_GET['id'])) {	// Read
+				$session->require_authorization(Permission::READ_CARD);
 
-			try {
 				$model = new CardModel(Config::config());
 				$card = $model->read($_GET['id']);
-				if($card) {
-					$transformer = new CardTransformer();
-					ResponseHandler::render($card, $transformer);
-				} else {
-					http_response_code(404);
-					die('We have no record of that card');
+				if(!$card) {
+					throw new NotFoundException('We have no record of that card');
 				}
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
-			}
-		} elseif(isset($_GET['search']) && !empty($_GET['search'])) {
-			$search_id = $_GET['search'];
 
-			$session->require_authorization(Permission::READ_CARD);
+				$transformer = new CardTransformer();
+				ResponseHandler::render($card, $transformer);
+			} elseif(isset($_GET['search']) && !empty($_GET['search'])) {
+				$search_id = $_GET['search'];
 
-			try {
+				$session->require_authorization(Permission::READ_CARD);
+
 				$model = new CardModel(Config::config());
 				$query = (new CardQuery())->set_id($search_id);
 				$cards = $model->search($query);
 
 				$transformer = new CardTransformer();
 				ResponseHandler::render($cards, $transformer);
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
-			}
-		} else { // Lists
-			$user_id = NULL;
+			} else { // Lists
+				$user_id = NULL;
 
-			// check authorization
-			if($session->check_authorization(Permission::LIST_OWN_CARDS)) {
-				if(!$session->check_authorization(Permission::LIST_CARDS)) {
-					$user_id = $session->get_authenticated_user()->id();
+				// check authorization
+				if($session->check_authorization(Permission::LIST_OWN_CARDS)) {
+					if(!$session->check_authorization(Permission::LIST_CARDS)) {
+						$user_id = $session->get_authenticated_user()->id();
+					}
+				} else {
+					$session->require_authorization(Permission::LIST_CARDS);
 				}
-			} else {
-				$session->require_authorization(Permission::LIST_CARDS);
-			}
 
-			try {
 				$model = new CardModel(Config::config());
 				$query = new CardQuery();
 				if(isset($_GET['equipment_type_id']) && !empty($_GET['equipment_type_id'])) {
@@ -75,41 +64,36 @@ switch($_SERVER['REQUEST_METHOD']) {
 				$cards = $model->search($query);
 				$transformer = new CardTransformer();
 				ResponseHandler::render($cards, $transformer);
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
 			}
-		}
-		break;
-	case 'PUT':		// Create
-		// check authorization
-		$session->require_authorization(Permission::CREATE_CARD);
+			break;
+		case 'PUT':		// Create
+			// check authorization
+			$session->require_authorization(Permission::CREATE_CARD);
 
-		$data = json_decode(file_get_contents('php://input'), TRUE);
-		if(NULL !== $data) {
-			try {
-				$transformer = new CardTransformer();
-				$card = $transformer->deserialize($data);
-				$model = new CardModel(Config::config());
-				$card = $model->create($card);
-				ResponseHandler::render($card, $transformer);
-			} catch(InvalidArgumentException $iae) {
-				http_response_code(400);
-				die($iae->getMessage());
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
+			$data = json_decode(file_get_contents('php://input'), TRUE);
+			if($data === null) {
+				throw new InvalidArgumentException(json_last_error_msg());
 			}
-		} else {
-			http_response_code(400);
-			die(json_last_error_msg());
-		}
-		break;
-	case 'DELETE':	// Delete
-		// intentional fall through, deletion not allowed
-	case 'POST': // Update
-		// intentional fall through, editing cards not allowed
-	default:
-		http_response_code(405);
-		die('We were unable to understand your request.');
+
+			$transformer = new CardTransformer();
+			$card = $transformer->deserialize($data);
+			$model = new CardModel(Config::config());
+			$card = $model->create($card);
+			ResponseHandler::render($card, $transformer);
+			break;
+		case 'DELETE':	// Delete
+			// intentional fall through, deletion not allowed
+		case 'POST': // Update
+			// intentional fall through, editing cards not allowed
+		default:
+			http_response_code(405);
+			die('We were unable to understand your request.');
+	}
+} catch(Throwable $t) {
+	ResponseHandler::setResponseCode($t);
+	$message = $t->getMessage();
+	if (empty($message)) {
+		$message = ResponseHandler::GENERIC_ERROR_MESSAGE;
+	}
+	die($message);
 }

--- a/public/api/charges.php
+++ b/public/api/charges.php
@@ -5,6 +5,7 @@ require '../../src/autoload.php';
 use Portalbox\Config;
 use Portalbox\ResponseHandler;
 use Portalbox\Entity\Permission;
+use Portalbox\Exception\NotFoundException;
 use Portalbox\Model\ChargeModel;
 use Portalbox\Query\ChargeQuery;
 use Portalbox\Session\Session;
@@ -12,41 +13,32 @@ use Portalbox\Transform\ChargeTransformer;
 
 $session = new Session();
 
-// switch on the request method
-switch($_SERVER['REQUEST_METHOD']) {
-	case 'GET':		// List/Read
-		if(isset($_GET['id']) && !empty($_GET['id'])) {	// Read
-			// echo "test";
-			
-			$session->require_authorization(Permission::READ_CHARGE);
+try {
+	switch($_SERVER['REQUEST_METHOD']) {
+		case 'GET':		// List/Read
+			if(isset($_GET['id']) && !empty($_GET['id'])) {	// Read
+				$session->require_authorization(Permission::READ_CHARGE);
 
-			try {
 				$model = new ChargeModel(Config::config());
 				$charge = $model->read($_GET['id']);
-				if($charge) {
-					$transformer = new ChargeTransformer();
-					ResponseHandler::render($charge, $transformer);
+				if(!$charge) {
+					throw new NotFoundException('We have no record of that charge');
+				}
+
+				$transformer = new ChargeTransformer();
+				ResponseHandler::render($charge, $transformer);
+			} else { // List
+				$user_id = NULL;
+
+				// check authorization
+				if($session->check_authorization(Permission::LIST_OWN_CHARGES)) {
+					if(!$session->check_authorization(Permission::LIST_CHARGES)) {
+						$user_id = $session->get_authenticated_user()->id();
+					}
 				} else {
-					http_response_code(404);
-					die('We have no record of that charge');
+					$session->require_authorization(Permission::LIST_CHARGES);
 				}
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
-			}
-		} else { // List
-			$user_id = NULL;
 
-			// check authorization
-			if($session->check_authorization(Permission::LIST_OWN_CHARGES)) {
-				if(!$session->check_authorization(Permission::LIST_CHARGES)) {
-					$user_id = $session->get_authenticated_user()->id();
-				}
-			} else {
-				$session->require_authorization(Permission::LIST_CHARGES);
-			}
-
-			try {
 				$model = new ChargeModel(Config::config());
 				$query = new ChargeQuery();
 				
@@ -70,70 +62,55 @@ switch($_SERVER['REQUEST_METHOD']) {
 				$charges = $model->search($query);
 				$transformer = new ChargeTransformer();
 				ResponseHandler::render($charges, $transformer);
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
 			}
-		}
-		break;
-	case 'POST':	// Update
-		// validate that we have an oid
-		if(!isset($_GET['id']) || empty($_GET['id'])) {
-			http_response_code(400);
-			die('You must specify the charge to modify via the id param');
-		}
-
-		// check authorization
-		$session->require_authorization(Permission::MODIFY_CHARGE);
-
-		$data = json_decode(file_get_contents('php://input'), TRUE);
-		if(NULL !== $data) {
-			try {
-				$transformer = new ChargeTransformer();
-				$charge = $transformer->deserialize($data);
-				$charge->set_id($_GET['id']);
-				$model = new ChargeModel(Config::config());
-				$charge = $model->update($charge);
-				ResponseHandler::render($charge, $transformer);
-			} catch(InvalidArgumentException $iae) {
-				http_response_code(400);
-				die($iae->getMessage());
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
+			break;
+		case 'POST':	// Update
+			// validate that we have an oid
+			if(!isset($_GET['id']) || empty($_GET['id'])) {
+				throw new InvalidArgumentException('You must specify the charge to modify via the id param');
 			}
-		} else {
-			http_response_code(400);
-			die(json_last_error_msg());
-		}
-		break;
-	case 'PUT':		// Create
-		// check authorization
-		$session->require_authorization(Permission::CREATE_CHARGE);
 
-		$data = json_decode(file_get_contents('php://input'), TRUE);
-		if(NULL !== $data) {
-			try {
-				$transformer = new ChargeTransformer();
-				$charge = $transformer->deserialize($data);
-				$model = new ChargeModel(Config::config());
-				$charge = $model->create($charge);
-				ResponseHandler::render($charge, $transformer);
-			} catch(InvalidArgumentException $iae) {
-				http_response_code(400);
-				die($iae->getMessage());
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
+			// check authorization
+			$session->require_authorization(Permission::MODIFY_CHARGE);
+
+			$data = json_decode(file_get_contents('php://input'), TRUE);
+			if($data === null) {
+				throw new InvalidArgumentException(json_last_error_msg());
 			}
-		} else {
-			http_response_code(400);
-			die(json_last_error_msg());
-		}
-		break;
-	case 'DELETE':	// Delete
-		// intentional fall through, deletion not allowed, but maybe it should be?
-	default:
-		http_response_code(405);
-		die('We were unable to understand your request.');
+
+			$transformer = new ChargeTransformer();
+			$charge = $transformer->deserialize($data);
+			$charge->set_id($_GET['id']);
+			$model = new ChargeModel(Config::config());
+			$charge = $model->update($charge);
+			ResponseHandler::render($charge, $transformer);
+			break;
+		case 'PUT':		// Create
+			// check authorization
+			$session->require_authorization(Permission::CREATE_CHARGE);
+
+			$data = json_decode(file_get_contents('php://input'), TRUE);
+			if($data === null) {
+				throw new InvalidArgumentException(json_last_error_msg());
+			}
+
+			$transformer = new ChargeTransformer();
+			$charge = $transformer->deserialize($data);
+			$model = new ChargeModel(Config::config());
+			$charge = $model->create($charge);
+			ResponseHandler::render($charge, $transformer);
+			break;
+		case 'DELETE':	// Delete
+			// intentional fall through, deletion not allowed, but maybe it should be?
+		default:
+			http_response_code(405);
+			die('We were unable to understand your request.');
+	}
+} catch(Throwable $t) {
+	ResponseHandler::setResponseCode($t);
+	$message = $t->getMessage();
+	if (empty($message)) {
+		$message = ResponseHandler::GENERIC_ERROR_MESSAGE;
+	}
+	die($message);
 }

--- a/public/api/config.php
+++ b/public/api/config.php
@@ -10,17 +10,21 @@ use Portalbox\ResponseHandler;
 
 use Portalbox\Transform\ConfigOutputTransformer;
 
-switch($_SERVER['REQUEST_METHOD']) {
-	case 'GET':
-		try {
+try {
+	switch($_SERVER['REQUEST_METHOD']) {
+		case 'GET':
 			$transformer = new ConfigOutputTransformer();
 			ResponseHandler::render(Config::config(), $transformer);
-		} catch(Exception $e) {
-			http_response_code(500);
-			die('Unable to read settings from config file.');
-		}
-		break;
-	default: // config is read only
-		http_response_code(405);
-		die('We were unable to understand your request.');
+			break;
+		default: // config is read only
+			http_response_code(405);
+			die('We were unable to understand your request.');
+	}
+} catch(Throwable $t) {
+	ResponseHandler::setResponseCode($t);
+	$message = $t->getMessage();
+	if (empty($message)) {
+		$message = ResponseHandler::GENERIC_ERROR_MESSAGE;
+	}
+	die($message);
 }

--- a/public/api/equipment-types.php
+++ b/public/api/equipment-types.php
@@ -5,107 +5,85 @@ require '../../src/autoload.php';
 use Portalbox\Config;
 use Portalbox\ResponseHandler;
 use Portalbox\Entity\Permission;
+use Portalbox\Exception\NotFoundException;
 use Portalbox\Model\EquipmentTypeModel;
 use Portalbox\Session\Session;
 use Portalbox\Transform\EquipmentTypeTransformer;
 
 $session = new Session();
 
-// switch on the request method
-switch($_SERVER['REQUEST_METHOD']) {
-	case 'GET':		// List/Read
-		if(isset($_GET['id']) && !empty($_GET['id'])) {	// Read
-			// check authorization
-			$session->require_authorization(Permission::READ_EQUIPMENT_TYPE);
+try {
+	switch($_SERVER['REQUEST_METHOD']) {
+		case 'GET':		// List/Read
+			if(isset($_GET['id']) && !empty($_GET['id'])) {	// Read
+				// check authorization
+				$session->require_authorization(Permission::READ_EQUIPMENT_TYPE);
 
-			try {
 				$model = new EquipmentTypeModel(Config::config());
 				$equipment_type = $model->read($_GET['id']);
-				if($equipment_type) {
-					$transformer = new EquipmentTypeTransformer();
-					ResponseHandler::render($equipment_type, $transformer);
-				} else {
-					http_response_code(404);
-					die('We have no record of that equipment type');
+				if(!$equipment_type) {
+					throw new NotFoundException('We have no record of that equipment type');
 				}
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
-			}
-		} else { // List
-			// check authorization
-			$session->require_authorization(Permission::LIST_EQUIPMENT_TYPES);
 
-			try {
+				$transformer = new EquipmentTypeTransformer();
+				ResponseHandler::render($equipment_type, $transformer);
+			} else { // List
+				// check authorization
+				$session->require_authorization(Permission::LIST_EQUIPMENT_TYPES);
+
 				$model = new EquipmentTypeModel(Config::config());
 				$equipment_types = $model->search();
 				$transformer = new EquipmentTypeTransformer();
 				ResponseHandler::render($equipment_types, $transformer);
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
 			}
-		}
-		break;
-	case 'POST':	// Update
-		// validate that we have an oid
-		if(!isset($_GET['id']) || empty($_GET['id'])) {
-			http_response_code(400);
-			die('You must specify the equipment type to modify via the id param');
-		}
-
-		// check authorization
-		$session->require_authorization(Permission::MODIFY_EQUIPMENT_TYPE);
-
-		$data = json_decode(file_get_contents('php://input'), TRUE);
-		if(NULL !== $data) {
-			try {
-				$transformer = new EquipmentTypeTransformer();
-				$equipment_type = $transformer->deserialize($data);
-				$equipment_type->set_id($_GET['id']);
-				$model = new EquipmentTypeModel(Config::config());
-				$equipment_type = $model->update($equipment_type);
-				ResponseHandler::render($equipment_type, $transformer);
-			} catch(InvalidArgumentException $iae) {
-				http_response_code(400);
-				die($iae->getMessage());
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
+			break;
+		case 'POST':	// Update
+			// validate that we have an oid
+			if(!isset($_GET['id']) || empty($_GET['id'])) {
+				throw new InvalidArgumentException('You must specify the equipment type to modify via the id param');
 			}
-		} else {
-			http_response_code(400);
-			die(json_last_error_msg());
-		}
-		break;
-	case 'PUT':	// Create
-		// check authorization
-		$session->require_authorization(Permission::CREATE_EQUIPMENT_TYPE);
 
-		$data = json_decode(file_get_contents('php://input'), TRUE);
-		if(NULL !== $data) {
-			try {
-				$transformer = new EquipmentTypeTransformer();
-				$equipment_type = $transformer->deserialize($data);
-				$model = new EquipmentTypeModel(Config::config());
-				$equipment_type = $model->create($equipment_type);
-				ResponseHandler::render($equipment_type, $transformer);
-			} catch(InvalidArgumentException $iae) {
-				http_response_code(400);
-				die($iae->getMessage());
-			} catch(Exception $e) {
-				error_log($e->getMessage());
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
+			// check authorization
+			$session->require_authorization(Permission::MODIFY_EQUIPMENT_TYPE);
+
+			$data = json_decode(file_get_contents('php://input'), TRUE);
+			if($data === null) {
+				throw new InvalidArgumentException(json_last_error_msg());
 			}
-		} else {
-			http_response_code(400);
-			die(json_last_error_msg());
-		}
-		break;
-	case 'DELETE':	// Delete
-		// intentional fall through, deletion not allowed
-	default:
-		http_response_code(405);
-		die('We were unable to understand your request.');
+
+			$transformer = new EquipmentTypeTransformer();
+			$equipment_type = $transformer->deserialize($data);
+			$equipment_type->set_id($_GET['id']);
+			$model = new EquipmentTypeModel(Config::config());
+			$equipment_type = $model->update($equipment_type);
+			ResponseHandler::render($equipment_type, $transformer);
+			break;
+		case 'PUT':	// Create
+			// check authorization
+			$session->require_authorization(Permission::CREATE_EQUIPMENT_TYPE);
+
+			$data = json_decode(file_get_contents('php://input'), TRUE);
+			if($data === null) {
+				throw new InvalidArgumentException(json_last_error_msg());
+			}
+
+			$transformer = new EquipmentTypeTransformer();
+			$equipment_type = $transformer->deserialize($data);
+			$model = new EquipmentTypeModel(Config::config());
+			$equipment_type = $model->create($equipment_type);
+			ResponseHandler::render($equipment_type, $transformer);
+			break;
+		case 'DELETE':	// Delete
+			// intentional fall through, deletion not allowed
+		default:
+			http_response_code(405);
+			die('We were unable to understand your request.');
+	}
+} catch(Throwable $t) {
+	ResponseHandler::setResponseCode($t);
+	$message = $t->getMessage();
+	if (empty($message)) {
+		$message = ResponseHandler::GENERIC_ERROR_MESSAGE;
+	}
+	die($message);
 }

--- a/public/api/equipment.php
+++ b/public/api/equipment.php
@@ -5,6 +5,7 @@ require '../../src/autoload.php';
 use Portalbox\Config;
 use Portalbox\ResponseHandler;
 use Portalbox\Entity\Permission;
+use Portalbox\Exception\NotFoundException;
 use Portalbox\Model\EquipmentModel;
 use Portalbox\Model\EquipmentTypeModel;
 use Portalbox\Model\LocationModel;
@@ -14,33 +15,24 @@ use Portalbox\Transform\EquipmentTransformer;
 
 $session = new Session();
 
-// switch on the request method
-switch($_SERVER['REQUEST_METHOD']) {
-	case 'GET':		// List/Read
-		if(isset($_GET['id']) && !empty($_GET['id'])) {	// Read
-			
-			// check authorization
-			$session->require_authorization(Permission::READ_EQUIPMENT);
-			
-			try {
+try {
+	switch($_SERVER['REQUEST_METHOD']) {
+		case 'GET':		// List/Read
+			if(isset($_GET['id']) && !empty($_GET['id'])) {	// Read
+				// check authorization
+				$session->require_authorization(Permission::READ_EQUIPMENT);
+
 				$model = new EquipmentModel(Config::config());
 				$equipment = $model->read($_GET['id']);
-				if($equipment) {
-					$transformer = new EquipmentTransformer();
-					ResponseHandler::render($equipment, $transformer);
-				} else {
-					http_response_code(404);
-					die('We have no record of that equipment');
+				if(!$equipment) {
+					throw new NotFoundException('We have no record of that equipment');
 				}
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
-			}
-			
-		} else { // List
-			// no authorization check as unauthenticated users may use
 
-			try {
+				$transformer = new EquipmentTransformer();
+				ResponseHandler::render($equipment, $transformer);
+			} else { // List
+				// no authorization check as unauthenticated users may use
+
 				$model = new EquipmentModel(Config::config());
 				$query = new EquipmentQuery();
 				if(isset($_GET['location_id']) && !empty($_GET['location_id'])) {
@@ -58,70 +50,55 @@ switch($_SERVER['REQUEST_METHOD']) {
 				$equipment = $model->search($query);
 				$transformer = new EquipmentTransformer();
 				ResponseHandler::render($equipment, $transformer);
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
 			}
-		}
-		break;
-	case 'POST':	// Update
-		// validate that we have an oid
-		if(!isset($_GET['id']) || empty($_GET['id'])) {
-			http_response_code(400);
-			die('You must specify the equipment to modify via the id param');
-		}
-
-		// check authorization
-		$session->require_authorization(Permission::MODIFY_EQUIPMENT);
-		$data = json_decode(file_get_contents('php://input'), TRUE);
-
-		if(NULL !== $data) {
-			try {
-				$transformer = new EquipmentTransformer();
-				$equipment = $transformer->deserialize($data);
-				$equipment->set_id($_GET['id']);
-				$model = new EquipmentModel(Config::config());
-				$equipment = $model->update($equipment);
-				ResponseHandler::render($equipment, $transformer);
-			} catch(InvalidArgumentException $iae) {
-				http_response_code(400);
-				die($iae->getMessage());
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
+			break;
+		case 'POST':	// Update
+			// validate that we have an oid
+			if(!isset($_GET['id']) || empty($_GET['id'])) {
+				throw new InvalidArgumentException('You must specify the equipment to modify via the id param');
 			}
-		} else {
-			http_response_code(400);
-			die(json_last_error_msg());
-		}
-		break;
-	case 'PUT':		// Create
-		// check authorization
-		$session->require_authorization(Permission::CREATE_EQUIPMENT);
 
-		$data = json_decode(file_get_contents('php://input'), TRUE);
-		if(NULL !== $data) {
-			try {
-				$transformer = new EquipmentTransformer();
-				$equipment = $transformer->deserialize($data);
-				$model = new EquipmentModel(Config::config());
-				$equipment = $model->create($equipment);
-				ResponseHandler::render($equipment, $transformer);
-			} catch(InvalidArgumentException $iae) {
-				http_response_code(400);
-				die($iae->getMessage());
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
+			// check authorization
+			$session->require_authorization(Permission::MODIFY_EQUIPMENT);
+
+			$data = json_decode(file_get_contents('php://input'), TRUE);
+			if($data === null) {
+				throw new InvalidArgumentException(json_last_error_msg());
 			}
-		} else {
-			http_response_code(400);
-			die(json_last_error_msg());
-		}
-		break;
-	case 'DELETE':	// Delete
-		// intentional fall through, deletion not allowed
-	default:
-		http_response_code(405);
-		die('We were unable to understand your request.');
+
+			$transformer = new EquipmentTransformer();
+			$equipment = $transformer->deserialize($data);
+			$equipment->set_id($_GET['id']);
+			$model = new EquipmentModel(Config::config());
+			$equipment = $model->update($equipment);
+			ResponseHandler::render($equipment, $transformer);
+			break;
+		case 'PUT':		// Create
+			// check authorization
+			$session->require_authorization(Permission::CREATE_EQUIPMENT);
+
+			$data = json_decode(file_get_contents('php://input'), TRUE);
+			if($data === null) {
+				throw new InvalidArgumentException(json_last_error_msg());
+			}
+
+			$transformer = new EquipmentTransformer();
+			$equipment = $transformer->deserialize($data);
+			$model = new EquipmentModel(Config::config());
+			$equipment = $model->create($equipment);
+			ResponseHandler::render($equipment, $transformer);
+			break;
+		case 'DELETE':	// Delete
+			// intentional fall through, deletion not allowed
+		default:
+			http_response_code(405);
+			die('We were unable to understand your request.');
+	}
+} catch(Throwable $t) {
+	ResponseHandler::setResponseCode($t);
+	$message = $t->getMessage();
+	if (empty($message)) {
+		$message = ResponseHandler::GENERIC_ERROR_MESSAGE;
+	}
+	die($message);
 }

--- a/public/api/payments.php
+++ b/public/api/payments.php
@@ -5,6 +5,7 @@ require '../../src/autoload.php';
 use Portalbox\Config;
 use Portalbox\ResponseHandler;
 use Portalbox\Entity\Permission;
+use Portalbox\Exception\NotFoundException;
 use Portalbox\Model\PaymentModel;
 use Portalbox\Query\PaymentQuery;
 use Portalbox\Session\Session;
@@ -12,40 +13,33 @@ use Portalbox\Transform\PaymentTransformer;
 
 $session = new Session();
 
-// switch on the request method
-switch($_SERVER['REQUEST_METHOD']) {
-	case 'GET':		// List/Read
-		if(isset($_GET['id']) && !empty($_GET['id'])) {	// Read
-			// check authorization
-			$session->require_authorization(Permission::READ_PAYMENT);
+try {
+	switch($_SERVER['REQUEST_METHOD']) {
+		case 'GET':		// List/Read
+			if(isset($_GET['id']) && !empty($_GET['id'])) {	// Read
+				// check authorization
+				$session->require_authorization(Permission::READ_PAYMENT);
 
-			try {
 				$model = new PaymentModel(Config::config());
 				$payment = $model->read($_GET['id']);
-				if($payment) {
-					$transformer = new PaymentTransformer();
-					ResponseHandler::render($payment, $transformer);
+				if(!$payment) {
+					throw new NotFoundException('We have no record of that payment');
+				}
+
+				$transformer = new PaymentTransformer();
+				ResponseHandler::render($payment, $transformer);
+			} else { // List
+				$user_id = NULL;
+
+				// check authorization
+				if($session->check_authorization(Permission::LIST_OWN_PAYMENTS)) {
+					if(!$session->check_authorization(Permission::LIST_PAYMENTS)) {
+						$user_id = $session->get_authenticated_user()->id();
+					}
 				} else {
-					http_response_code(404);
-					die('We have no record of that payment');
+					$session->require_authorization(Permission::LIST_PAYMENTS);
 				}
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
-			}
-		} else { // List
-			$user_id = NULL;
 
-			// check authorization
-			if($session->check_authorization(Permission::LIST_OWN_PAYMENTS)) {
-				if(!$session->check_authorization(Permission::LIST_PAYMENTS)) {
-					$user_id = $session->get_authenticated_user()->id();
-				}
-			} else {
-				$session->require_authorization(Permission::LIST_PAYMENTS);
-			}
-
-			try {
 				$model = new PaymentModel(Config::config());
 				$query = new PaymentQuery();
 				if(NULL !== $user_id) {
@@ -63,70 +57,55 @@ switch($_SERVER['REQUEST_METHOD']) {
 				$payments = $model->search($query);
 				$transformer = new PaymentTransformer();
 				ResponseHandler::render($payments, $transformer);
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
 			}
-		}
-		break;
-	case 'POST':	// Update
-		// validate that we have an oid
-		if(!isset($_GET['id']) || empty($_GET['id'])) {
-			http_response_code(400);
-			die('You must specify the payment to modify via the id param');
-		}
-
-		// check authorization
-		$session->require_authorization(Permission::MODIFY_PAYMENT);
-
-		$data = json_decode(file_get_contents('php://input'), TRUE);
-		if(NULL !== $data) {
-			try {
-				$transformer = new PaymentTransformer();
-				$payment = $transformer->deserialize($data);
-				$payment->set_id($_GET['id']);
-				$model = new PaymentModel(Config::config());
-				$payment = $model->update($payment);
-				ResponseHandler::render($payment, $transformer);
-			} catch(InvalidArgumentException $iae) {
-				http_response_code(400);
-				die($iae->getMessage());
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
+			break;
+		case 'POST':	// Update
+			// validate that we have an oid
+			if(!isset($_GET['id']) || empty($_GET['id'])) {
+				throw new InvalidArgumentException('You must specify the payment to modify via the id param');
 			}
-		} else {
-			http_response_code(400);
-			die(json_last_error_msg());
-		}
-		break;
-	case 'PUT':		// Create
-		// check authorization
-		$session->require_authorization(Permission::CREATE_PAYMENT);
 
-		$data = json_decode(file_get_contents('php://input'), TRUE);
-		if(NULL !== $data) {
-			try {
-				$transformer = new PaymentTransformer();
-				$payment = $transformer->deserialize($data);
-				$model = new PaymentModel(Config::config());
-				$payment = $model->create($payment);
-				ResponseHandler::render($payment, $transformer);
-			} catch(InvalidArgumentException $iae) {
-				http_response_code(400);
-				die($iae->getMessage());
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
+			// check authorization
+			$session->require_authorization(Permission::MODIFY_PAYMENT);
+
+			$data = json_decode(file_get_contents('php://input'), TRUE);
+			if($data === null) {
+				throw new InvalidArgumentException(json_last_error_msg());
 			}
-		} else {
-			http_response_code(400);
-			die(json_last_error_msg());
-		}
-		break;
-	case 'DELETE':	// Delete
-		// intentional fall through, deletion not allowed, but maybe it should be?
-	default:
-		http_response_code(405);
-		die('We were unable to understand your request.');
+
+			$transformer = new PaymentTransformer();
+			$payment = $transformer->deserialize($data);
+			$payment->set_id($_GET['id']);
+			$model = new PaymentModel(Config::config());
+			$payment = $model->update($payment);
+			ResponseHandler::render($payment, $transformer);
+			break;
+		case 'PUT':		// Create
+			// check authorization
+			$session->require_authorization(Permission::CREATE_PAYMENT);
+
+			$data = json_decode(file_get_contents('php://input'), TRUE);
+			if($data === null) {
+				throw new InvalidArgumentException(json_last_error_msg());
+			}
+
+			$transformer = new PaymentTransformer();
+			$payment = $transformer->deserialize($data);
+			$model = new PaymentModel(Config::config());
+			$payment = $model->create($payment);
+			ResponseHandler::render($payment, $transformer);
+			break;
+		case 'DELETE':	// Delete
+			// intentional fall through, deletion not allowed, but maybe it should be?
+		default:
+			http_response_code(405);
+			die('We were unable to understand your request.');
+	}
+} catch(Throwable $t) {
+	ResponseHandler::setResponseCode($t);
+	$message = $t->getMessage();
+	if (empty($message)) {
+		$message = ResponseHandler::GENERIC_ERROR_MESSAGE;
+	}
+	die($message);
 }

--- a/public/api/roles.php
+++ b/public/api/roles.php
@@ -5,106 +5,85 @@ require '../../src/autoload.php';
 use Portalbox\Config;
 use Portalbox\ResponseHandler;
 use Portalbox\Entity\Permission;
+use Portalbox\Exception\NotFoundException;
 use Portalbox\Model\RoleModel;
 use Portalbox\Session\Session;
 use Portalbox\Transform\RoleTransformer;
 
 $session = new Session();
 
-// switch on the request method
-switch($_SERVER['REQUEST_METHOD']) {
-	case 'GET':		// List/Read
-		if(isset($_GET['id']) && !empty($_GET['id'])) {	// Read
-			// check authorization
-			$session->require_authorization(Permission::READ_ROLE);
+try {
+	switch($_SERVER['REQUEST_METHOD']) {
+		case 'GET':		// List/Read
+			if(isset($_GET['id']) && !empty($_GET['id'])) {	// Read
+				// check authorization
+				$session->require_authorization(Permission::READ_ROLE);
 
-			try {
 				$model = new RoleModel(Config::config());
 				$role = $model->read($_GET['id']);
-				if($role) {
-					$transformer = new RoleTransformer();
-					ResponseHandler::render($role, $transformer);
-				} else {
-					http_response_code(404);
-					die('We have no record of that role');
+				if(!$role) {
+					throw new NotFoundException('We have no record of that role');
 				}
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
-			}
-		} else { // List
-			// check authorization
-			$session->require_authorization(Permission::LIST_ROLES);
 
-			try {
+				$transformer = new RoleTransformer();
+				ResponseHandler::render($role, $transformer);
+			} else { // List
+				// check authorization
+				$session->require_authorization(Permission::LIST_ROLES);
+
 				$model = new RoleModel(Config::config());
 				$roles = $model->search();
 				$transformer = new RoleTransformer();
 				ResponseHandler::render($roles, $transformer);
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
 			}
-		}
-		break;
-	case 'POST':	// Update
-		// validate that we have an oid
-		if(!isset($_GET['id']) || empty($_GET['id'])) {
-			http_response_code(400);
-			die('You must specify the role to modify via the id param');
-		}
-
-		// check authorization
-		$session->require_authorization(Permission::MODIFY_ROLE);
-
-		$data = json_decode(file_get_contents('php://input'), TRUE);
-		if(NULL !== $data) {
-			try {
-				$transformer = new RoleTransformer();
-				$role = $transformer->deserialize($data);
-				$role->set_id($_GET['id']);
-				$model = new RoleModel(Config::config());
-				$role = $model->update($role);
-				ResponseHandler::render($role, $transformer);
-			} catch(InvalidArgumentException $iae) {
-				http_response_code(400);
-				die($iae->getMessage());
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
+			break;
+		case 'POST':	// Update
+			// validate that we have an oid
+			if(!isset($_GET['id']) || empty($_GET['id'])) {
+				throw new InvalidArgumentException('You must specify the role to modify via the id param');
 			}
-		} else {
-			http_response_code(400);
-			die(json_last_error_msg());
-		}
-		break;
-	case 'PUT':		// Create
-		// check authorization
-		$session->require_authorization(Permission::CREATE_ROLE);
 
-		$data = json_decode(file_get_contents('php://input'), TRUE);
-		if(NULL !== $data) {
-			try {
-				$transformer = new RoleTransformer();
-				$role = $transformer->deserialize($data);
-				$model = new RoleModel(Config::config());
-				$role = $model->create($role);
-				ResponseHandler::render($role, $transformer);
-			} catch(InvalidArgumentException $iae) {
-				http_response_code(400);
-				die($iae->getMessage());
-			} catch(Exception $e) {
-				http_response_code(500);
-				die('We experienced issues communicating with the database');
+			// check authorization
+			$session->require_authorization(Permission::MODIFY_ROLE);
+
+			$data = json_decode(file_get_contents('php://input'), TRUE);
+			if($data === null) {
+				throw new InvalidArgumentException(json_last_error_msg());
 			}
-		} else {
-			http_response_code(400);
-			die(json_last_error_msg());
-		}
-		break;
-	case 'DELETE':	// Delete
-		// intentional fall through, deletion not allowed
-	default:
-		http_response_code(405);
-		die('We were unable to understand your request.');
+
+			$transformer = new RoleTransformer();
+			$role = $transformer->deserialize($data);
+			$role->set_id($_GET['id']);
+			$model = new RoleModel(Config::config());
+			$role = $model->update($role);
+			ResponseHandler::render($role, $transformer);
+			break;
+		case 'PUT':		// Create
+			// check authorization
+			$session->require_authorization(Permission::CREATE_ROLE);
+
+			$data = json_decode(file_get_contents('php://input'), TRUE);
+			if($data === null) {
+				throw new InvalidArgumentException(json_last_error_msg());
+			}
+
+			$transformer = new RoleTransformer();
+			$role = $transformer->deserialize($data);
+			$model = new RoleModel(Config::config());
+			$role = $model->create($role);
+			ResponseHandler::render($role, $transformer);
+			break;
+		case 'DELETE':	// Delete
+			// intentional fall through, deletion not allowed
+		default:
+			http_response_code(405);
+			die('We were unable to understand your request.');
+	}
+} catch(Throwable $t) {
+	ResponseHandler::setResponseCode($t);
+	$message = $t->getMessage();
+	if (empty($message)) {
+		$message = ResponseHandler::GENERIC_ERROR_MESSAGE;
+	}
+	die($message);
 }

--- a/public/api/users.php
+++ b/public/api/users.php
@@ -5,9 +5,6 @@ require '../../src/autoload.php';
 use Portalbox\Config;
 use Portalbox\ResponseHandler;
 use Portalbox\Entity\Permission;
-use Portalbox\Exception\AuthenticationException;
-use Portalbox\Exception\AuthorizationException;
-use Portalbox\Exception\NotFoundException;
 use Portalbox\Model\EquipmentTypeModel;
 use Portalbox\Model\RoleModel;
 use Portalbox\Model\UserModel;
@@ -19,7 +16,6 @@ use Portalbox\Transform\UserTransformer;
 $session = new Session();
 
 try {
-	// switch on the request method
 	switch($_SERVER['REQUEST_METHOD']) {
 		case 'GET': // List/Read
 			if(isset($_GET['id']) && !empty($_GET['id'])) {	// Read
@@ -124,23 +120,11 @@ try {
 			http_response_code(405);
 			die('We were unable to understand your request.');
 	}
-} catch(InvalidArgumentException $iae) {
-	http_response_code(400);
-	die($iae->getMessage());
-} catch (AuthenticationException $ae) {
-	http_response_code(401);
-	die($session->ERROR_NOT_AUTHENTICATED);
-} catch (AuthorizationException $aue) {
-	http_response_code(403);
-	die(self::ERROR_NOT_AUTHORIZED);
-} catch (NotFoundException $nfe) {
-	http_response_code(404);
-	die($nfe->getMessage());
 } catch(Throwable $t) {
-	http_response_code(500);
+	ResponseHandler::setResponseCode($t);
 	$message = $t->getMessage();
 	if (empty($message)) {
-		$message = 'We experienced issues communicating with the database';
+		$message = ResponseHandler::GENERIC_ERROR_MESSAGE;
 	}
 	die($message);
 }

--- a/src/ResponseHandler.php
+++ b/src/ResponseHandler.php
@@ -3,8 +3,12 @@
 namespace Portalbox;
 
 use InvalidArgumentException;
+use Portalbox\Exception\AuthenticationException;
+use Portalbox\Exception\AuthorizationException;
+use Portalbox\Exception\NotFoundException;
 use Portalbox\Transform\NullOutputTransformer;
 use Portalbox\Transform\OutputTransformer;
+use Throwable;
 
 /**
  * OutputTransformer - Is used to send encoded responses to a requester. Can
@@ -13,6 +17,8 @@ use Portalbox\Transform\OutputTransformer;
  * list_item_to_array.
  */
 class ResponseHandler {
+	public const GENERIC_ERROR_MESSAGE = 'An error occurred and unfortunately, we don\'t know how to describe it.';
+
 	/**
 	 * Encodes and sends data to the requester
 	 *
@@ -36,6 +42,28 @@ class ResponseHandler {
 			self::render_list_response($transformer, $data);
 		} else {
 			self::render_entity_response($transformer, $data);
+		}
+	}
+
+	/**
+	 * Set the HTTP response code based on exception type
+	 */
+	public static function setResponseCode(Throwable $t) {
+		switch ($t::class) {
+			case InvalidArgumentException::class:
+				http_response_code(400);
+				break;
+			case AuthenticationException::class:
+				http_response_code(401);
+				break;
+			case AuthorizationException::class:
+				http_response_code(403);
+				break;
+			case NotFoundException::class:
+				http_response_code(404);
+				break;
+			default:
+				http_response_code(500);
 		}
 	}
 

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -35,6 +35,8 @@ class UserService {
 	public const ERROR_INACTIVE_FILTER_MUST_BE_BOOL = 'The value of include_inactive must be a boolean';
 	public const ERROR_ROLE_FILTER_MUST_BE_INT = 'The value of role_id must be an integer';
 	public const ERROR_EQUIPMENT_FILTER_MUST_BE_INT = 'The value of equipment_id must be an integer';
+	public const ERROR_UNAUTHENTICATED_READ = 'You ust be authenticated to read users';
+	public const ERROR_UNAUTHENTICATED_WRITE = 'You must be authenticated to modify users';
 
 	protected SessionInterface $session;
 	protected EquipmentTypeModel $equipmentTypeModel;
@@ -131,7 +133,7 @@ class UserService {
 	public function read(int $userId): User {
 		$authenticatedUser = $this->session->get_authenticated_user();
 		if ($authenticatedUser === null) {
-			throw new AuthenticationException();
+			throw new AuthenticationException(self::ERROR_UNAUTHENTICATED_READ);
 		}
 
 		$role = $authenticatedUser->role();
@@ -166,7 +168,7 @@ class UserService {
 	public function readAll(array $filters): array {
 		$authenticatedUser = $this->session->get_authenticated_user();
 		if ($authenticatedUser === null) {
-			throw new AuthenticationException();
+			throw new AuthenticationException(self::ERROR_UNAUTHENTICATED_READ);
 		}
 
 		if (!$authenticatedUser->role()->has_permission(Permission::LIST_USERS)) {
@@ -236,7 +238,7 @@ class UserService {
 	 */
 	public function patch(int $userId, string $filePath): User {
 		if ($this->session->get_authenticated_user() === null) {
-			throw new AuthenticationException();
+			throw new AuthenticationException(self::ERROR_UNAUTHENTICATED_WRITE);
 		}
 
 		$user = $this->userModel->read($userId);

--- a/test/ResponseHandlerTest.php
+++ b/test/ResponseHandlerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Portalbox;
+
+use Exception;
+use InvalidArgumentException;
+use PDOException;
+use PHPUnit\Framework\TestCase;
+use Portalbox\Exception\AuthenticationException;
+use Portalbox\Exception\AuthorizationException;
+use Portalbox\Exception\NotFoundException;
+use Portalbox\ResponseHandler;
+
+final class ResponseHandlerTest extends TestCase {
+	/**
+	 * @dataProvider getExceptions
+	 */
+	public function testSetResponseCode($error, int $responseCode) {
+		ResponseHandler::setResponseCode($error);
+		self::assertSame($responseCode, http_response_code());
+	}
+
+	public static function getExceptions(): iterable {
+		yield [new InvalidArgumentException(), 400];
+
+		yield [new AuthenticationException(), 401];
+
+		yield [new AuthorizationException(), 403];
+
+		yield [new NotFoundException(), 404];
+
+		yield [new Exception(), 500];
+
+		yield [new PDOException(), 500];
+	}
+}

--- a/test/Service/UserServiceTest.php
+++ b/test/Service/UserServiceTest.php
@@ -174,6 +174,7 @@ final class UserServiceTest extends TestCase {
 		);
 
 		self::expectException(AuthenticationException::class);
+		self::expectExceptionMessage(UserService::ERROR_UNAUTHENTICATED_READ);
 		$service->read(1);
 	}
 
@@ -344,6 +345,7 @@ final class UserServiceTest extends TestCase {
 		);
 
 		self::expectException(AuthenticationException::class);
+		self::expectExceptionMessage(UserService::ERROR_UNAUTHENTICATED_READ);
 		$service->readAll([]);
 	}
 
@@ -585,6 +587,7 @@ final class UserServiceTest extends TestCase {
 		);
 
 		self::expectException(AuthenticationException::class);
+		self::expectExceptionMessage(UserService::ERROR_UNAUTHENTICATED_WRITE);
 		$service->patch(1, '');
 	}
 


### PR DESCRIPTION
This PR if accepted does a fair bit of rearranging in the `public/api/*.php` inorder to extract the common exception handling code into a generic catch block. This simplifies the code a bit and make it a tad bit more covered in unit tests.