### PR TITLE
fix: remember search params when searching for cards

### DIFF
--- a/public/views/authenticated/cards/list.mst
+++ b/public/views/authenticated/cards/list.mst
@@ -10,8 +10,8 @@
 		</div>
 	</header>
 	<form class="advanced_search" onsubmit="return false;">
-		<label for="card_id">Search:</label>
-		<input name="card_id" id="card_id" onchange="app.search_cards(this.form, 'admin');" value="{{search}}" autocomplete="off" />
+		<label for="card">Search:</label>
+		<input name="card" id="card" onchange="app.search_cards(this.form);" value="{{search.card}}" autocomplete="off" />
 	</form>
 	<table>
 		<thead>

--- a/src/Service/CardService.php
+++ b/src/Service/CardService.php
@@ -205,8 +205,8 @@ class CardService {
 			$query->set_equipment_type_id($equipment_type_id);
 		}
 
-		if(isset($filters['search']) && !empty($filters['search'])) {
-			$id = filter_var($filters['search'], FILTER_VALIDATE_INT);
+		if(isset($filters['card']) && !empty($filters['card'])) {
+			$id = filter_var($filters['card'], FILTER_VALIDATE_INT);
 			if ($id === false) {
 				throw new InvalidArgumentException(self::ERROR_ID_FILTER_MUST_BE_INT);
 			}

--- a/test/Service/CardServiceTest.php
+++ b/test/Service/CardServiceTest.php
@@ -743,7 +743,7 @@ final class CardServiceTest extends TestCase {
 
 		self::expectException(InvalidArgumentException::class);
 		self::expectExceptionMessage(CardService::ERROR_ID_FILTER_MUST_BE_INT);
-		$service->readAll(['search' => 'meh']);
+		$service->readAll(['card' => 'meh']);
 	}
 
 	public function testReadAllThrowsWhenUserFilterIsNotInteger() {
@@ -936,7 +936,7 @@ final class CardServiceTest extends TestCase {
 		];
 
 		yield [
-			['search' => '12'],
+			['card' => '12'],
 			NULL,
 			NULL,
 			12


### PR DESCRIPTION
This PR if accepted brings a small quality of life enhancement when searching cards; the search is not cleared when the results are displayed.