### PR TITLE
feature add ability to search portalboxes by MAC

### DIFF
--- a/public/api/equipment.php
+++ b/public/api/equipment.php
@@ -43,8 +43,11 @@ try {
 				if(isset($_GET['type']) && !empty($_GET['type'])) {
 					$query->set_type($_GET['type']);
 				}
-				if(isset($_GET['include_out_of_service']) && !empty($_GET['include_out_of_service'])) {
-					$query->set_include_out_of_service(true);
+				if(
+					!isset($_GET['include_out_of_service'])
+					|| empty($_GET['include_out_of_service'])
+				) {
+					$query->set_exclude_out_of_service(true);
 				}
 
 				$equipment = $model->search($query);

--- a/public/views/authenticated/equipment/list.mst
+++ b/public/views/authenticated/equipment/list.mst
@@ -12,15 +12,13 @@
 		{{/create_equipment_permission}}
 	</header>
 	<form>
-		{{#search}}
 		<label for="include_out_of_service">Include &quot;Out of Service&quot;:</label>
 		<input
-			onchange="this.form.submit()"
+			onchange="app.list_equipment(this.form);"
 			type="checkbox"
 			name="include_out_of_service"
 			id="include_out_of_service"
-			{{#include_out_of_service}}checked{{/include_out_of_service}} />
-		{{/search}}
+			{{#search.include_out_of_service}}checked{{/search.include_out_of_service}} />
 	</form>
 	<table>
 		<thead>

--- a/src/Model/ChargeModel.php
+++ b/src/Model/ChargeModel.php
@@ -206,7 +206,6 @@ class ChargeModel extends AbstractModel {
 		$u_model = new UserModel($this->Configuration());
 
 		$e_query = new EquipmentQuery();
-		$e_query->set_include_out_of_service(true);
 		$u_query = (new UserQuery())
 			->set_include_inactive(true);
 

--- a/src/Model/EquipmentModel.php
+++ b/src/Model/EquipmentModel.php
@@ -170,6 +170,12 @@ class EquipmentModel extends AbstractModel {
 
 		$where_clause_fragments = [];
 		$parameters = [];
+
+		if (null !== $query->mac_address()) {
+			$where_clause_fragments[] = 'e.mac_address = :mac_address';
+			$parameters[':mac_address'] = $query->mac_address();
+		}
+
 		if (null !== $query->location_id()) {
 			$where_clause_fragments[] = 'l.id = :location';
 			$parameters[':location'] = $query->location_id();
@@ -177,13 +183,13 @@ class EquipmentModel extends AbstractModel {
 			$where_clause_fragments[] = 'l.name = :location';
 			$parameters[':location'] = $query->location();
 		}
+
 		if (null !== $query->type()) {
 			$where_clause_fragments[] = 't.name = :type';
 			$parameters[':type'] = $query->type();
 		}
-		if ($query->include_out_of_service()) {
-			// do nothing i.e. do not filter for in service only
-		} else {
+
+		if ($query->exclude_out_of_service()) {
 			$where_clause_fragments[] = 'e.in_service = 1';
 		}
 

--- a/src/Query/EquipmentQuery.php
+++ b/src/Query/EquipmentQuery.php
@@ -6,11 +6,14 @@ namespace Portalbox\Query;
  * EquipmentQuery presents a standard interface for Equipment search queries
  */
 class EquipmentQuery {
-	/** Whether to find out of service equipment */
-	protected bool $include_out_of_service = false;
+	/** Whether to exclude out of service equipment */
+	protected bool $exclude_out_of_service = false;
 
 	/** Find equipment by named type */
 	protected ?string $type = null;
+
+	/** Find equipment by MAC address */
+	protected ?string $mac_address = null;
 
 	/** Find equipment in the named location */
 	protected ?string $location = null;
@@ -21,14 +24,14 @@ class EquipmentQuery {
 	/** The ip address of the portalbox attached to the equipment */
 	protected ?string $ip_address = null;
 
-	/** Get whether to find out of service equipment */
-	public function include_out_of_service(): bool {
-		return $this->include_out_of_service;
+	/** Get whether to exclude out of service equipment */
+	public function exclude_out_of_service(): bool {
+		return $this->exclude_out_of_service;
 	}
 
-	/** Set whether to find out of service equipment */
-	public function set_include_out_of_service(bool $include_out_of_service): self {
-		$this->include_out_of_service = $include_out_of_service;
+	/** Set whether to exclude out of service equipment */
+	public function set_exclude_out_of_service(bool $exclude_out_of_service): self {
+		$this->exclude_out_of_service = $exclude_out_of_service;
 		return $this;
 	}
 
@@ -37,9 +40,29 @@ class EquipmentQuery {
 		return $this->type;
 	}
 
-	/** Set the name of the equipmen type */
+	/** Set the name of the equipment type */
 	public function set_type(?string $type): self {
 		$this->type = $type;
+		return $this;
+	}
+
+	/** Get the MAC address */
+	public function mac_address(): ?string {
+		return $this->mac_address;
+	}
+
+	/**
+	 * Set the MAC address
+	 *
+	 * Note we transform the value in a manner consistent with how addresses are
+	 * stored in the database for simplicity later
+	 */
+	public function set_mac_address(?string $mac_address): self {
+		if ($mac_address) {
+			$mac_address = strtolower(str_replace(['-', ':'], '', $mac_address));
+		}
+
+		$this->mac_address = $mac_address;
 		return $this;
 	}
 

--- a/test/Query/EquipmentQueryTest.php
+++ b/test/Query/EquipmentQueryTest.php
@@ -10,25 +10,31 @@ use Portalbox\Query\EquipmentQuery;
 final class EquipmentQueryTest extends TestCase {
 	public function testAgreement(): void {
 		$type = 'Hyperspanner';
+		$mac_address = '00:11:22:CC:AA:BB';
+		$normalized_mac_address = '001122ccaabb';
 		$location = 'Space Dock';
 		$location_id = 99;
-		$include_out_of_service = true;
+		$exclude_out_of_service = true;
 
 		$query = new EquipmentQuery();
 
-		self::assertFalse($query->include_out_of_service());
+		self::assertFalse($query->exclude_out_of_service());
+		self::assertNull($query->mac_address());
 		self::assertNull($query->location());
 		self::assertNull($query->location_id());
 		self::assertNull($query->type());
-		
-		$query->set_include_out_of_service($include_out_of_service);
-		$query->set_location($location);
-		$query->set_location_id($location_id);
-		$query->set_type($type);
 
-		self::assertEquals($include_out_of_service, $query->include_out_of_service());
-		self::assertEquals($location, $query->location());
-		self::assertEquals($location_id, $query->location_id());
-		self::assertEquals($type, $query->type());
+		$query
+			->set_exclude_out_of_service($exclude_out_of_service)
+			->set_mac_address($mac_address)
+			->set_location($location)
+			->set_location_id($location_id)
+			->set_type($type);
+
+		self::assertSame($exclude_out_of_service, $query->exclude_out_of_service());
+		self::assertSame($normalized_mac_address, $query->mac_address());
+		self::assertSame($location, $query->location());
+		self::assertSame($location_id, $query->location_id());
+		self::assertSame($type, $query->type());
 	}
 }


### PR DESCRIPTION
This PR if accepted addes the ability to search for portalboxes by MAC which will be helpful when registering new portalboxes. It also fixes an issue with filtering out of service portalboxes for authenticated users; previously the page would reload before displaying the results  making it seem like the search did not work.