### PR TITLE
fix: roles did not appear in menu for admins with default permissions

### DIFF
--- a/public/js/Application.js
+++ b/public/js/Application.js
@@ -509,7 +509,7 @@ class Application {
 		}
 
 		// User needs LIST_ROLES Permission to make use of /roles route
-		if(this.user.has_permission(Permission.LIST_ROLES) && this.user.has_permission(Permission.VIEW_ROLES)) {
+		if(this.user.has_permission(Permission.LIST_ROLES) && this.user.has_permission(Permission.READ_ROLE)) {
 			if(!home_icons.system) { home_icons.system = system_icons }
 			home_icons.system.roles = true;
 			this.route("/roles", _ => {
@@ -520,7 +520,7 @@ class Application {
 		}
 
 		// User needs READ_ROLE to make use of /roles/id
-		if(this.user.has_permission(Permission.READ_ROLE) && this.user.has_permission(Permission.VIEW_ROLES)) {
+		if(this.user.has_permission(Permission.READ_ROLE)) {
 			// User needs MODIFY_ROLE to make use of /roles/id for editing
 			this.route("/roles/:id", params => this.read_role(params.id, this.user.has_permission(Permission.MODIFY_ROLE), this.user.has_permission(Permission.DELETE_ROLE)));
 		}

--- a/public/js/Permission.js
+++ b/public/js/Permission.js
@@ -276,9 +276,6 @@ export const DELETE_ROLE = 1104;
 /** Users with this permission can list roles */
 export const LIST_ROLES = 1105;
 
-/** Users with this permission can view the roles page */
-export const VIEW_ROLES = 1107;
-
 /** Users with this permission can create users */
 export const CREATE_USER = 1201;
 
@@ -362,7 +359,6 @@ let permissions = {
 	1103:{id:MODIFY_ROLE, name:"Modify roles"},
 	1104:{id:DELETE_ROLE, name:"Delete roles"},
 	1105:{id:LIST_ROLES, name:"List roles"},
-	1107:{id:VIEW_ROLES, name:"View roles"},
 	1201:{id:CREATE_USER, name:"Add users to system"},
 	1202:{id:READ_USER, name:"View user details"},
 	1203:{id:MODIFY_USER, name:"Modify users"},

--- a/src/Entity/Permission.php
+++ b/src/Entity/Permission.php
@@ -277,9 +277,6 @@ class Permission {
 	/** Users with this permission can list roles */
 	public const LIST_ROLES = 1105;
 
-	/** Users with this permission can view the roles page */
-	public const VIEW_ROLES = 1107;
-
 	/** Users with this permission can create users */
 	public const CREATE_USER = 1201;
 
@@ -360,7 +357,6 @@ class Permission {
 			self::MODIFY_ROLE,
 			self::DELETE_ROLE,
 			self::LIST_ROLES,
-			self::VIEW_ROLES,
 			self::CREATE_USER,
 			self::READ_USER,
 			self::MODIFY_USER,


### PR DESCRIPTION
The VIEW_ROLES permission was never added to the database schema and I can not remember why it exists in the code therefore I propose to remove it from the code in this PR thus resolving an issue where Roles did not appear in the menu for admins created with the default permissions.