### PR TITLE
chore: extend model layer to allow creating log entries

### DIFF
--- a/src/Model/ActivationModel.php
+++ b/src/Model/ActivationModel.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Portalbox\Model;
+
+use DateTimeImmutable;
+use Portalbox\Exception\DatabaseException;
+use PDO;
+
+/**
+ * Manage records of when portal boxes were most recently activated
+ */
+class ActivationModel extends AbstractModel {
+	/**
+	 * Create an activation record for the equipment with the given id
+	 *
+	 * @param int $id  the unique id of the equipment being activated
+	 * @return bool  true if the record was created
+	 * @throws DatabaseException  when the database can not be queried
+	 */
+	public function create(int $id): bool {
+		$connection = $this->configuration()->writable_db_connection();
+		$sql = 'INSERT INTO in_use (equipment_id) VALUES (:id)';
+		$query = $connection->prepare($sql);
+		$query->bindValue(':id', $id);
+
+		if (!$query->execute()) {
+			throw new DatabaseException($connection->errorInfo()[2]);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Read an activation record for the equipment with the given id
+	 *
+	 * @param int $id  the unique id of the activated equipment
+	 * @return DateTimeImmutable|null when the equipment was activated
+	 * @throws DatabaseException  when the database can not be queried
+	 */
+	public function read(int $id): ?DateTimeImmutable {
+		$connection = $this->configuration()->readonly_db_connection();
+
+		$sql = 'SELECT start_time FROM in_use WHERE equipment_id = :id';
+		$query = $connection->prepare($sql);
+		$query->bindValue(':id', $id, PDO::PARAM_INT);
+		if (!$query->execute()) {
+			throw new DatabaseException($connection->errorInfo()[2]);
+		}
+
+		$data = $query->fetchColumn();
+		if ($data) {
+			return new DateTimeImmutable($data);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Delete an activation record for the equipment with the given id
+	 *
+	 * @param int id  the unique id of the activated equipment
+	 * @return DateTimeImmutable|null  when the equipment was activated
+	 * @throws DatabaseException  when the database can not be queried
+	 */
+	public function delete(int $id): ?DateTimeImmutable {
+		$start_time = $this->read($id);
+
+		if ($start_time === null) {
+			return null;
+		}
+
+		$connection = $this->configuration()->writable_db_connection();
+		$sql = 'DELETE FROM in_use WHERE equipment_id = :id';
+		$query = $connection->prepare($sql);
+		$query->bindValue(':id', $id, PDO::PARAM_INT);
+		if (!$query->execute()) {
+			throw new DatabaseException($connection->errorInfo()[2]);
+		}
+
+		return $start_time;
+	}
+}

--- a/src/Model/EquipmentModel.php
+++ b/src/Model/EquipmentModel.php
@@ -146,16 +146,11 @@ class EquipmentModel extends AbstractModel {
 	/**
 	 * Search for Equipment
 	 *
-	 * @param EquipmentQuery query - the search query to perform
+	 * @param EquipmentQuery|null query - the search query to perform
 	 * @throws DatabaseException - when the database can not be queried
 	 * @return Equipment[]|null - a list of equipment which match the search query
 	 */
-	public function search(EquipmentQuery $query): ?array {
-		if (null === $query) {
-			// no query... bail
-			return null;
-		}
-
+	public function search(?EquipmentQuery $query = null): array {
 		$connection = $this->configuration()->readonly_db_connection();
 
 		$sql = <<<EOQ
@@ -171,31 +166,33 @@ class EquipmentModel extends AbstractModel {
 		$where_clause_fragments = [];
 		$parameters = [];
 
-		if (null !== $query->mac_address()) {
-			$where_clause_fragments[] = 'e.mac_address = :mac_address';
-			$parameters[':mac_address'] = $query->mac_address();
-		}
+		if ($query) {
+			if (null !== $query->mac_address()) {
+				$where_clause_fragments[] = 'e.mac_address = :mac_address';
+				$parameters[':mac_address'] = $query->mac_address();
+			}
 
-		if (null !== $query->location_id()) {
-			$where_clause_fragments[] = 'l.id = :location';
-			$parameters[':location'] = $query->location_id();
-		} else if (null !== $query->location()) {
-			$where_clause_fragments[] = 'l.name = :location';
-			$parameters[':location'] = $query->location();
-		}
+			if (null !== $query->location_id()) {
+				$where_clause_fragments[] = 'l.id = :location';
+				$parameters[':location'] = $query->location_id();
+			} else if (null !== $query->location()) {
+				$where_clause_fragments[] = 'l.name = :location';
+				$parameters[':location'] = $query->location();
+			}
 
-		if (null !== $query->type()) {
-			$where_clause_fragments[] = 't.name = :type';
-			$parameters[':type'] = $query->type();
-		}
+			if (null !== $query->type()) {
+				$where_clause_fragments[] = 't.name = :type';
+				$parameters[':type'] = $query->type();
+			}
 
-		if ($query->exclude_out_of_service()) {
-			$where_clause_fragments[] = 'e.in_service = 1';
-		}
+			if ($query->exclude_out_of_service()) {
+				$where_clause_fragments[] = 'e.in_service = 1';
+			}
 
-		if (0 < count($where_clause_fragments)) {
-			$sql .= ' WHERE ';
-			$sql .= implode(' AND ', $where_clause_fragments);
+			if (0 < count($where_clause_fragments)) {
+				$sql .= ' WHERE ';
+				$sql .= implode(' AND ', $where_clause_fragments);
+			}
 		}
 		$sql .= ' ORDER BY l.name, t.name, e.name';
 
@@ -205,16 +202,19 @@ class EquipmentModel extends AbstractModel {
 			$statement->bindValue($k, $v);
 		}
 
-		if ($statement->execute()) {
-			$data = $statement->fetchAll(PDO::FETCH_ASSOC);
-			if (false !== $data) {
-				return $this->buildEquipmentFromArrays($data);
-			} else {
-				return null;
-			}
-		} else {
+		if (!$statement->execute()) {
 			throw new DatabaseException($connection->errorInfo()[2]);
 		}
+
+		$data = $statement->fetchAll(PDO::FETCH_ASSOC);
+		if ($data === false) {
+			return [];
+		}
+
+		return array_map(
+			fn (array $record) => $this->buildEquipmentFromArray($record),
+			$data
+		);
 	}
 
 	private function buildEquipmentFromArray(array $data): Equipment {
@@ -229,15 +229,5 @@ class EquipmentModel extends AbstractModel {
 					->set_is_in_use($data['in_use'])
 					->set_service_minutes($data['service_minutes'])
 					->set_ip_address($data['ip_address']);
-	}
-
-	private function buildEquipmentFromArrays(array $data): array {
-		$equipment = [];
-
-		foreach ($data as $datum) {
-			$equipment[] = $this->buildEquipmentFromArray($datum);
-		}
-
-		return $equipment;
 	}
 }

--- a/src/Model/LoggedEventModel.php
+++ b/src/Model/LoggedEventModel.php
@@ -12,6 +12,23 @@ use PDO;
  * LoggedEventModel is our bridge between the database and higher level Entities.
  */
 class LoggedEventModel extends AbstractModel {
+	public function create(LoggedEvent $event): LoggedEvent {
+		$connection = $this->configuration()->writable_db_connection();
+		$sql = 'INSERT INTO log (event_type_id, card_id, time, equipment_id) VALUES (:event_type_id, :card_id, :time, :equipment_id)';
+		$query = $connection->prepare($sql);
+
+		$query->bindValue(':event_type_id', $event->type_id(), PDO::PARAM_INT);
+		$query->bindValue(':card_id', $event->card_id(), PDO::PARAM_INT);
+		$query->bindValue(':equipment_id', $event->equipment_id(), PDO::PARAM_INT);
+		$query->bindValue(':time', $event->time());
+
+		if (!$query->execute()) {
+			throw new DatabaseException($connection->errorInfo()[2]);
+		}
+
+		return $event->set_id($connection->lastInsertId('log_id_seq'));
+	}
+
 	/**
 	 * Read a logged event by its unique ID
 	 *

--- a/test/Model/ActivationModelTest.php
+++ b/test/Model/ActivationModelTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Portalbox\Model;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use Portalbox\Config;
+use Portalbox\Entity\ChargePolicy;
+use Portalbox\Entity\Equipment;
+use Portalbox\Entity\EquipmentType;
+use Portalbox\Entity\Location;
+use Portalbox\Model\ActivationModel;
+use Portalbox\Model\EquipmentModel;
+use Portalbox\Model\EquipmentTypeModel;
+use Portalbox\Model\LocationModel;
+
+final class ActivationModelTest extends TestCase {
+	/** A location that exists in the db */
+	private static Location $location;
+
+	/** An equipment type which exists in the db */
+	private static EquipmentType $type;
+
+	/** The configuration */
+	private static Config $config;
+
+	/** An Equipment/device/portalbox that exists in the db */
+	private static Equipment $equipment;
+
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		self::$config = Config::config();
+
+		// provision a location in the db
+		$model = new LocationModel(self::$config);
+
+		$name = 'Robotics Shop';
+
+		$location = (new Location())
+			->set_name($name);
+
+		self::$location = $model->create($location);
+
+		// provision an equipment type in the db
+		$model = new EquipmentTypeModel(self::$config);
+
+		$name = 'Floodlight';
+		$requires_training = false;
+		$charge_policy_id = ChargePolicy::NO_CHARGE;
+
+		$type = (new EquipmentType())
+			->set_name($name)
+			->set_requires_training($requires_training)
+			->set_charge_policy_id($charge_policy_id)
+			->set_allow_proxy(false);
+
+		self::$type = $model->create($type);
+
+		// provision an equipment in the db
+		$model = new EquipmentModel(self::$config);
+
+		$name = '1000W Floodlight';
+		$mac_address = '0123456789AB';
+		$timeout = 0;
+		$is_in_service = true;
+		$service_minutes = 500;
+
+		$equipment = (new Equipment())
+			->set_name($name)
+			->set_type(self::$type)
+			->set_location(self::$location)
+			->set_mac_address($mac_address)
+			->set_timeout($timeout)
+			->set_is_in_service($is_in_service)
+			->set_service_minutes($service_minutes);
+
+		self::$equipment = $model->create($equipment);
+	}
+
+	public static function tearDownAfterClass(): void {
+		// deprovision an equipment in the db
+		$model = new EquipmentModel(self::$config);
+		$model->delete(self::$equipment->id());
+
+		// deprovision a location in the db
+		$model = new LocationModel(self::$config);
+		$model->delete(self::$location->id());
+
+		// deprovision an equipment type in the db
+		$model = new EquipmentTypeModel(self::$config);
+		$model->delete(self::$type->id());
+
+		parent::tearDownAfterClass();
+	}
+
+	public function testCreateReadDelete(): void {
+		$model = new ActivationModel(self::$config);
+
+		self::assertTrue($model->create(self::$equipment->id()));
+
+		$start_time = $model->read(self::$equipment->id());
+		self::assertInstanceOf(DateTimeImmutable::class, $start_time);
+
+		self::assertEquals($start_time, $model->delete(self::$equipment->id()));
+
+		self::assertNull($model->read(self::$equipment->id()));
+	}
+}

--- a/test/Model/EquipmentModelTest.php
+++ b/test/Model/EquipmentModelTest.php
@@ -204,6 +204,15 @@ final class EquipmentModelTest extends TestCase {
 		)->id();
 
 		// Test that we can get all equipment
+		$equipmentIds = array_map(
+			fn (Equipment $equipment) => $equipment->id(),
+			$model->search()
+		);
+
+		self::assertContains($equipmentId1, $equipmentIds);
+		self::assertContains($equipmentId2, $equipmentIds);
+		self::assertContains($equipmentId3, $equipmentIds);
+
 		$query = new EquipmentQuery();
 		$equipmentIds = array_map(
 			fn (Equipment $equipment) => $equipment->id(),


### PR DESCRIPTION
This PR if accepted adds the ability to create log entries and create/delete activation records to the "model" or database abstraction layer. This will help us build readable request handlers for portalbox activation session start and end requests.