### PR TITLE
fix: incorrect syntax for specifying rate minimum bound

### DIFF
--- a/src/Service/EquipmentTypeService.php
+++ b/src/Service/EquipmentTypeService.php
@@ -198,7 +198,7 @@ class EquipmentTypeService {
 		$chargeRate = filter_var(
 			$data['charge_rate'] ?? '',
 			FILTER_VALIDATE_FLOAT,
-			['min_range' => 0.0]
+			['options' => ['min_range' => 0.0]]
 		);
 		if ($chargeRate === false) {
 			throw new InvalidArgumentException(self::ERROR_INVALID_RATE);

--- a/test/Service/EquipmentTypeServiceTest.php
+++ b/test/Service/EquipmentTypeServiceTest.php
@@ -218,6 +218,29 @@ final class EquipmentTypeServiceTest extends TestCase {
 		$service->create(realpath(__DIR__ . '/EquipmentTypeServiceTestData/ChargeRateIsInvalid.json'));
 	}
 
+	public function testCreateThrowsWhenChargeRateIsOutOfRange() {
+		$session = $this->createStub(SessionInterface::class);
+		$session->method('get_authenticated_user')->willReturn(
+			(new User())
+				->set_role(
+					(new Role())
+						->set_id(2)
+						->set_permissions([Permission::CREATE_EQUIPMENT_TYPE])
+				)
+		);
+
+		$equipmentTypeModel = $this->createStub(EquipmentTypeModel::class);
+
+		$service = new EquipmentTypeService(
+			$session,
+			$equipmentTypeModel
+		);
+
+		self::expectException(InvalidArgumentException::class);
+		self::expectExceptionMessage(EquipmentTypeService::ERROR_INVALID_RATE);
+		$service->create(realpath(__DIR__ . '/EquipmentTypeServiceTestData/ChargeRateIsOutOfRange.json'));
+	}
+
 	public function testCreateThrowsWhenAllowProxyIsInvalid() {
 		$session = $this->createStub(SessionInterface::class);
 		$session->method('get_authenticated_user')->willReturn(
@@ -301,7 +324,7 @@ final class EquipmentTypeServiceTest extends TestCase {
 
 	#endregion test create()
 	
-	#region test readAll()
+	#region test read()
 
 	public function testReadThrowsWhenNotAuthenticated() {
 		$session = $this->createStub(SessionInterface::class);
@@ -386,7 +409,7 @@ final class EquipmentTypeServiceTest extends TestCase {
 		self::assertSame($type, $service->read(1));
 	}
 
-	#endregion test readAll()
+	#endregion test read()
 
 	#region test readAll()
 
@@ -682,6 +705,30 @@ final class EquipmentTypeServiceTest extends TestCase {
 		self::expectException(InvalidArgumentException::class);
 		self::expectExceptionMessage(EquipmentTypeService::ERROR_INVALID_RATE);
 		$service->update(1, realpath(__DIR__ . '/EquipmentTypeServiceTestData/ChargeRateIsInvalid.json'));
+	}
+
+	public function testUpdateThrowsWhenChargeRateIsOutOfRange() {
+		$session = $this->createStub(SessionInterface::class);
+		$session->method('get_authenticated_user')->willReturn(
+			(new User())
+				->set_role(
+					(new Role())
+						->set_id(2)
+						->set_permissions([Permission::MODIFY_EQUIPMENT_TYPE])
+				)
+		);
+
+		$equipmentTypeModel = $this->createStub(EquipmentTypeModel::class);
+		$equipmentTypeModel->method('read')->willReturn(new EquipmentType());
+
+		$service = new EquipmentTypeService(
+			$session,
+			$equipmentTypeModel
+		);
+
+		self::expectException(InvalidArgumentException::class);
+		self::expectExceptionMessage(EquipmentTypeService::ERROR_INVALID_RATE);
+		$service->update(1, realpath(__DIR__ . '/EquipmentTypeServiceTestData/ChargeRateIsOutOfRange.json'));
 	}
 
 	public function testUpdateThrowsWhenAllowProxyIsInvalid() {

--- a/test/Service/EquipmentTypeServiceTestData/ChargeRateIsOutOfRange.json
+++ b/test/Service/EquipmentTypeServiceTestData/ChargeRateIsOutOfRange.json
@@ -1,0 +1,1 @@
+{"name":"Flashlight", "requires_training": false, "charge_policy_id": 2, "charge_rate": "-1.25", "allow_proxy": true}


### PR DESCRIPTION
This PR if accept fixes some incorrect syntax for specifying the lower bound for charge rate and adds unit tests to demonstrate code now works as expected.